### PR TITLE
🚑 [user-simulator] Revert node upgrade due to resulting crash

### DIFF
--- a/src/user-simulator/Dockerfile
+++ b/src/user-simulator/Dockerfile
@@ -1,5 +1,5 @@
 # based on snippet from https://github.com/puppeteer/puppeteer/blob/main/docs/troubleshooting.md
-FROM node:18.11.0
+FROM node:14.20.0
 
 # Install latest chrome dev package and fonts to support major charsets (Chinese, Japanese, Arabic, Hebrew, Thai and a few others)
 # Note: this installs the necessary libs to make the bundled version of Chromium that Puppeteer installs, work.


### PR DESCRIPTION
Node JS upgrade in the `user-simulator` Dockerfile resulted in the containers crashing directly after starting with the following error message:

```
> Error! An unexpected error occurred!
  Error: error:0308010C:digital envelope routines::unsupported
    at new Hash (node:internal/crypto/hash:71:19)
    at Object.createHash (node:crypto:133:10)
...
```

Reverted back to NodeJS 14.20.0 to fix that.