### PR TITLE
[Bugfix]  Change docker image of proxy-service to pinned version

### DIFF
--- a/src/proxy-service/Dockerfile
+++ b/src/proxy-service/Dockerfile
@@ -1,8 +1,8 @@
-FROM gradle:jdk8 as builder
+FROM openjdk:8u111-jdk-alpine as builder
 
-COPY --chown=gradle:gradle . /home/gradle/src
+COPY . /home/gradle/src
 WORKDIR /home/gradle/src
-RUN gradle build
+RUN ./gradlew build
 RUN ls build/libs/
 
 # force JDK < 8u121 to provoke CVE-2021-44228 10.0 RCE in log4j < 2.4.1


### PR DESCRIPTION
Change docker image to a pinned version and use gadlew for building

The gradle version used in "gradle:jdk8" was updated to version 8.x, causing the build to fail.
We are using now a pinned openjdk image and use the gradle wrapper to download and build with the desired gradle version 6.8.3.