### PR TITLE
[Bugfix] Membership service enable retry db connection

### DIFF
--- a/src/membership-service/Program.cs
+++ b/src/membership-service/Program.cs
@@ -49,6 +49,7 @@ namespace MembershipService
                 {
                     var logger = services.GetRequiredService<ILogger<Program>>();
                     logger.LogError(ex, "An error occurred creating the DB.");
+                    System.Environment.Exit(1);
                 }
             }
         }

--- a/src/membership-service/Startup.cs
+++ b/src/membership-service/Startup.cs
@@ -49,8 +49,12 @@ namespace MembershipService
             string connectString = $"Server={dbHost};Port=3306;Database=memberships;user=root;password={dbPwd}";
             services.AddDbContext<MariaDbContext>(
                 options => options.UseMySql(
-                connectString,
-                    new MySqlServerVersion(new Version(10, 5, 8))
+                    connectString,
+                    new MySqlServerVersion(new Version(10, 5, 8)),
+                    options => options.EnableRetryOnFailure(
+                        maxRetryCount: 10,
+                        maxRetryDelay: System.TimeSpan.FromSeconds(60),
+                        errorNumbersToAdd: null)
                 )
             );
 


### PR DESCRIPTION
When using ArgoCD for deployment, "wait:true" to wait for the database
in the skaffold.yaml, is not applied, instead all services are created
in parallel. The membership-service tries to connect once to the not yet ready db,
and then waits, doing nothing. To resolve this the option EnableRetryOnFailure
was added. We try to connect 10 times, with increasing delay each time. (e.g. first 10ms, second 150ms... up to 60s). If the connection cant be established at the 10th try, we get to the try-catch. Then we stop the program, and the pod restarts.
