### PR TITLE
[Bugfix] Fix invalid log4j2 xml config

### DIFF
--- a/src/proxy-service/src/main/resources/log4j2.xml
+++ b/src/proxy-service/src/main/resources/log4j2.xml
@@ -1,6 +1,7 @@
+<?xml version="1.0" encoding="UTF-8"?>
 <!--
 Copyright 2023 Dynatrace LLC
- 
+
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
 You may obtain a copy of the License at
@@ -13,8 +14,6 @@ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 See the License for the specific language governing permissions and
 limitations under the License.
 -->
-
-<?xml version="1.0" encoding="UTF-8"?>
 <Configuration>
     <Appenders>
         <Console name="Console" target="SYSTEM_OUT">


### PR DESCRIPTION
Fixes #38 .

This PR fixes the log4j2.xml config so it correctly starts with the XML declaration and does not get rejected on startup of the `proxy-service`.

Verified log4shell working locally:
![2023-03-14_13-57](https://user-images.githubusercontent.com/1103924/225034979-d74a7ac1-1168-4045-8d9b-3d79e3bd4fbb.png)
