### PR TITLE
👷 ci: add skaffold build ci action

### DIFF
--- a/.github/workflows/build-images.yaml
+++ b/.github/workflows/build-images.yaml
@@ -1,0 +1,44 @@
+name: Publish
+on:
+#  push:
+#    # Sequence of patterns matched against refs/heads
+#    branches:
+#      - main
+#    # Sequence of patterns matched against refs/tags
+#    tags:
+#      - v*
+  push:
+    paths:
+      - src/**
+      - .github/workflows/build-images.yaml
+jobs:
+  build:
+    name: Skaffold Build
+    runs-on: ubuntu-22.04
+    steps:
+      - name: Checkout sources
+        uses: actions/checkout@v3
+
+      - name: Log in to the Container registry
+        uses: docker/login-action@f054a8b539a109f9f41c372932f1ae047eff08c9
+        with:
+          registry: ${{ vars.REGISTRY }}
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Cache layers
+        uses: actions/cache@v3
+        with:
+          path: "${{ github.workspace }}/.skaffold/cache"
+          key: skaffold-${{ hashFiles('**/cache') }}
+          restore-keys: |
+            skaffold-
+
+      - name: Run Skaffold build pipeline
+        uses: hiberbee/github-action-skaffold@latest
+        id: build
+        with:
+          command: build
+          skip-tests: true
+          repository: ${{ vars.REGISTRY }}/${{ github.repository }}
+          push: true

--- a/.github/workflows/build-images.yaml
+++ b/.github/workflows/build-images.yaml
@@ -1,15 +1,9 @@
-name: Publish
+name: Build on PR
 on:
-#  push:
-#    # Sequence of patterns matched against refs/heads
-#    branches:
-#      - main
-#    # Sequence of patterns matched against refs/tags
-#    tags:
-#      - v*
-  push:
+  pull_request:
     paths:
       - src/**
+      - k8s-manifests
       - .github/workflows/build-images.yaml
 jobs:
   build:
@@ -18,13 +12,6 @@ jobs:
     steps:
       - name: Checkout sources
         uses: actions/checkout@v3
-
-      - name: Log in to the Container registry
-        uses: docker/login-action@f054a8b539a109f9f41c372932f1ae047eff08c9
-        with:
-          registry: ${{ vars.REGISTRY }}
-          username: ${{ github.actor }}
-          password: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Cache layers
         uses: actions/cache@v3
@@ -40,5 +27,4 @@ jobs:
         with:
           command: build
           skip-tests: true
-          repository: ${{ vars.REGISTRY }}/${{ github.repository }}
-          push: true
+          push: false

--- a/.github/workflows/build-images.yaml
+++ b/.github/workflows/build-images.yaml
@@ -22,7 +22,7 @@ jobs:
             skaffold-
 
       - name: Run Skaffold build pipeline
-        uses: hiberbee/github-action-skaffold@latest
+        uses: hiberbee/github-action-skaffold@1.26.0
         id: build
         with:
           command: build

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -30,7 +30,7 @@ jobs:
           echo "IMAGE_TAG=${{ steps.release-version.outputs.group1 }}" >> $GITHUB_ENV
 
       - name: Log in to the Container registry
-        uses: docker/login-action@f054a8b539a109f9f41c372932f1ae047eff08c9
+        uses: docker/login-action@v2
         with:
           registry: ${{ vars.REGISTRY }}
           username: ${{ github.actor }}
@@ -45,7 +45,7 @@ jobs:
             skaffold-
 
       - name: Run Skaffold build pipeline
-        uses: hiberbee/github-action-skaffold@latest
+        uses: hiberbee/github-action-skaffold@1.26.0
         id: build
         with:
           command: build

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -1,0 +1,55 @@
+name: Publish images
+on:
+  push:
+    branches:
+      - main
+      - 'release/**'
+jobs:
+  build:
+    name: Publish on container registry
+    runs-on: ubuntu-22.04
+    steps:
+      - name: Checkout sources
+        uses: actions/checkout@v3
+
+      - name: Get release version
+        if: startsWith(github.ref_name, 'release')
+        uses: actions-ecosystem/action-regex-match@v2
+        id: release-version
+        with:
+          text: ${{ github.ref_name }}
+          regex: '^release\/(.*)$'
+
+      - name: Set image tag
+        run: |
+          echo "IMAGE_TAG=${{ github.sha }}" >> $GITHUB_ENV
+
+      - name: Set image release tag
+        if: ${{ steps.release-version.outputs.match != '' }}
+        run: |
+          echo "IMAGE_TAG=${{ steps.release-version.outputs.group1 }}" >> $GITHUB_ENV
+
+      - name: Log in to the Container registry
+        uses: docker/login-action@f054a8b539a109f9f41c372932f1ae047eff08c9
+        with:
+          registry: ${{ vars.REGISTRY }}
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Cache layers
+        uses: actions/cache@v3
+        with:
+          path: "${{ github.workspace }}/.skaffold/cache"
+          key: skaffold-${{ hashFiles('**/cache') }}
+          restore-keys: |
+            skaffold-
+
+      - name: Run Skaffold build pipeline
+        uses: hiberbee/github-action-skaffold@latest
+        id: build
+        with:
+          command: build
+          skip-tests: true
+          tag: ${{ env.IMAGE_TAG }}
+          repository: ${{ vars.REGISTRY }}/${{ github.repository }}
+          push: true


### PR DESCRIPTION
This PR adds two new GitHub actions:
* One action that is run on every PR that simply builds all the images as a very weak form of catching errors that break the whole application
* One action that is run on pushing to a release branch, that builds and pushes the images to GHCR
    * Images are tagged with `{version}` based on the branch name `release/{version}`.
