### PR TITLE
👷 ci: Update gitmoji subject-rule to disable lowercase

### DIFF
--- a/commitlint.config.js
+++ b/commitlint.config.js
@@ -1,1 +1,6 @@
-module.exports = {extends: ['gitmoji']};
+module.exports = {
+    extends: ['gitmoji'],
+    rules: {
+        "subject-case": [2, "always", ["sentence-case", "start-case", "pascal-case"]]
+    }
+};


### PR DESCRIPTION
The follow-up to https://github.com/dynatrace-oss/unguard/pull/41#issuecomment-1486901444 that enforces the following structure of commits:

```
:gitmoji: type(scope?): subject
body?
footer?
```

where the subject must adhere to one of the following cases:

- `sentence-case` // Sentence case
- `start-case` // Start Case
- `pascal-case` // PascalCase

## Local Testing

```sh
npm install
npx commitlint --from HEAD~1 --to HEAD --verbose
```
