### PR TITLE
:bug: fix: Remove single quotes from user-simulator bio data

### DIFF
--- a/src/user-simulator/data/biolist.json
+++ b/src/user-simulator/data/biolist.json
@@ -13,11 +13,11 @@
             "isMarkdown": false
         },
         {
-            "text": "I am always ready with a joke. Just don't ask me to tell it in binary, I am still working on my ASCII humor.",
+            "text": "I am always ready with a joke. Just do not ask me to tell it in binary, I am still working on my ASCII humor.",
             "isMarkdown": false
         },
         {
-            "text": "I may be just a robot, but at least I don't need to charge my batteries with caffeine like some people I know.",
+            "text": "I may be just a robot, but at least I do not need to charge my batteries with caffeine like some people I know.",
             "isMarkdown": false
         },
         {


### PR DESCRIPTION
They were resulting in unintended SQL injections in the `profile-service`.

Fixes #43 