### PR TITLE
👷 ci: Remove the "v." prefix from the image tags

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -18,7 +18,7 @@ jobs:
         id: release-version
         with:
           text: ${{ github.ref_name }}
-          regex: '^release\/(.*)$'
+          regex: '^release\/v(.*)$'
 
       - name: Set image tag
         run: |


### PR DESCRIPTION
Edited release.yaml to remove the leading 'v.' in the image tag.