### PR TITLE
🐛 fix: Enforce LF style line endings for gradlew files

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -2,4 +2,6 @@
 # Set default behavior to automatically normalize line endings.
 ###############################################################################
 * text=auto encoding=UTF-8
-*.sh text eol=lf
+
+*.sh            text eol=lf
+gradlew         text eol=lf


### PR DESCRIPTION
This should fix the issue with Windows machines not being able to build docker images where `gradlew` is used.
Could not verify this myself, as I'm not on Windows, so please do so :)

Fixes #46