### PR TITLE
🐛 fix(tracing): Add missing default env variables to services

### DIFF
--- a/chart/templates/ad-service.yaml
+++ b/chart/templates/ad-service.yaml
@@ -66,7 +66,6 @@ spec:
               value: {{ quote .Values.adService.deployment.container.env.USER_AUTH_SERVICE_ADDRESS }}
             - name: JAEGER_SERVICE_NAME
               value: {{quote (printf "unguard-%s" .Values.adService.name) }}
-            {{if .Values.tracing.enabled}}
             - name: JAEGER_AGENT_HOST
               value: {{ quote (printf "%s-%s" .Values.jaeger.name .Values.adService.deployment.container.env.JAEGER_AGENT_HOST) }}
             - name: JAEGER_SAMPLER_TYPE
@@ -75,4 +74,3 @@ spec:
               value: {{ quote .Values.adService.deployment.container.env.JAEGER_SAMPLER_PARAM }}
             - name: JAEGER_DISABLED
               value: {{ quote .Values.adService.deployment.container.env.JAEGER_DISABLED }}
-            {{end}}

--- a/chart/templates/frontend.yaml
+++ b/chart/templates/frontend.yaml
@@ -79,7 +79,6 @@ spec:
               value: {{ quote .Values.frontend.deployment.container.env.MEMBERSHIP_SERVICE_BASE_PATH }}
             - name: STATUS_SERVICE_BASE_PATH
               value: {{ quote .Values.frontend.deployment.container.env.STATUS_SERVICE_BASE_PATH }}
-            {{if .Values.tracing.enabled}}
             - name: JAEGER_SERVICE_NAME
               value: {{quote (printf "unguard-%s" .Values.frontend.name) }}
             - name: JAEGER_AGENT_HOST
@@ -90,4 +89,3 @@ spec:
               value: {{ quote .Values.frontend.deployment.container.env.JAEGER_SAMPLER_PARAM }}
             - name: JAEGER_DISABLED
               value: {{ quote .Values.frontend.deployment.container.env.JAEGER_DISABLED }}
-            {{end}}

--- a/chart/templates/microblog-service.yaml
+++ b/chart/templates/microblog-service.yaml
@@ -63,7 +63,6 @@ spec:
               value: {{ quote .Values.microblogService.deployment.container.env.REDIS_SERVICE_ADDRESS }}
             - name: USER_AUTH_SERVICE_ADDRESS
               value: {{ quote .Values.microblogService.deployment.container.env.USER_AUTH_SERVICE_ADDRESS }}
-            {{if .Values.tracing.enabled}}
             - name: OPENTRACING_JAEGER_ENABLED
               value: {{ quote .Values.microblogService.deployment.container.env.OPENTRACING_JAEGER_ENABLED }}
             - name: JAEGER_SERVICE_NAME
@@ -74,4 +73,3 @@ spec:
               value: {{ quote .Values.microblogService.deployment.container.env.JAEGER_SAMPLER_TYPE }}
             - name: JAEGER_SAMPLER_PARAM
               value: {{ quote .Values.microblogService.deployment.container.env.JAEGER_SAMPLER_PARAM }}
-            {{end}}

--- a/chart/templates/proxy-service.yaml
+++ b/chart/templates/proxy-service.yaml
@@ -92,7 +92,6 @@ spec:
           env:
             - name: SERVER_PORT
               value: {{ quote .Values.proxyService.deployment.container.env.SERVER_PORT }}
-            {{if .Values.tracing.enabled}}
             - name: OPENTRACING_JAEGER_ENABLED
               value: {{ quote .Values.proxyService.deployment.container.env.OPENTRACING_JAEGER_ENABLED }}
             - name: JAEGER_SERVICE_NAME
@@ -103,4 +102,3 @@ spec:
               value: {{ quote .Values.proxyService.deployment.container.env.JAEGER_SAMPLER_TYPE }}
             - name: JAEGER_SAMPLER_PARAM
               value: {{ quote .Values.proxyService.deployment.container.env.JAEGER_SAMPLER_PARAM }}
-            {{end}}

--- a/chart/templates/user-auth-service.yaml
+++ b/chart/templates/user-auth-service.yaml
@@ -68,7 +68,6 @@ spec:
                   key: {{ tpl .Values.userAuthService.deployment.container.env.MARIADB_PASSWORD.secretKeyRef.key .  }}
             - name: JAEGER_SERVICE_NAME
               value: {{quote (printf "unguard-%s" .Values.userAuthService.name) }}
-            {{if .Values.tracing.enabled}}
             - name: JAEGER_AGENT_HOST
               value: {{quote (printf "%s-%s" .Values.jaeger.name .Values.userAuthService.deployment.container.env.JAEGER_AGENT_HOST) }}
             - name: JAEGER_SAMPLER_TYPE
@@ -77,4 +76,3 @@ spec:
               value: {{ quote .Values.userAuthService.deployment.container.env.JAEGER_SAMPLER_PARAM }}
             - name: JAEGER_DISABLED
               value: {{ quote .Values.userAuthService.deployment.container.env.JAEGER_DISABLED }}
-            {{end}}


### PR DESCRIPTION
Some environment variables regarding tracing were not present in the `tracing=disable` state, causing exceptions in the microblog and proxy service.
This PR implements all tracing variables in the same behavior as with skaffold.

Fixes #54 