### PR TITLE
✨ feat(envoy-proxy): Enable access logging for HTTP requests

### DIFF
--- a/src/envoy-proxy/config/envoy-config.yaml
+++ b/src/envoy-proxy/config/envoy-config.yaml
@@ -50,7 +50,17 @@ static_resources:
                           timestamp: "%START_TIME%"
                           upstream_remote_address: "%UPSTREAM_REMOTE_ADDRESS%"
                           user_agent: "%REQ(User-Agent)%"
+                          payload: "%DYNAMIC_METADATA(envoy.filters.http.lua.request-filter:payload)%"
                 http_filters:
+                  - name: envoy.filters.http.lua
+                    typed_config:
+                      "@type": type.googleapis.com/envoy.extensions.filters.http.lua.v3.Lua
+                      default_source_code:
+                        inline_string: |
+                          local request_logger = require("/etc/envoy/unguard/request-logger")
+                          function envoy_on_request(request_handle)
+                            request_logger.log_payload(request_handle)
+                          end
                   - name: envoy.filters.http.router
                     typed_config:
                       "@type": type.googleapis.com/envoy.extensions.filters.http.router.v3.Router

--- a/src/envoy-proxy/config/envoy-config.yaml
+++ b/src/envoy-proxy/config/envoy-config.yaml
@@ -38,6 +38,18 @@ static_resources:
                   - name: envoy.access_loggers.stdout
                     typed_config:
                       "@type": type.googleapis.com/envoy.extensions.access_loggers.stream.v3.StdoutAccessLog
+                      log_format:
+                        json_format:
+                          content_type: "%REQ(Content-Type)%"
+                          downstream_remote_address: "%DOWNSTREAM_REMOTE_ADDRESS%"
+                          hostname: "%HOSTNAME%"
+                          message: "%LOCAL_REPLY_BODY%"
+                          original_path: "%REQ(X-ENVOY-ORIGINAL-PATH?:PATH)%"
+                          response_code: "%RESPONSE_CODE%"
+                          response_code_details: "%RESPONSE_CODE_DETAILS%"
+                          timestamp: "%START_TIME%"
+                          upstream_remote_address: "%UPSTREAM_REMOTE_ADDRESS%"
+                          user_agent: "%REQ(User-Agent)%"
                 http_filters:
                   - name: envoy.filters.http.router
                     typed_config:

--- a/src/envoy-proxy/config/request-logger.lua
+++ b/src/envoy-proxy/config/request-logger.lua
@@ -1,0 +1,16 @@
+local request_logger = {}
+
+function request_logger.log_payload(handle)
+    local payload = ""
+    for chunk in handle:bodyChunks() do
+      local chunk_length = chunk:length()
+      if (chunk_length > 0) then
+        payload = payload .. chunk:getBytes(0, chunk_length)
+      end
+    end
+    payload = tostring(payload)
+    handle:streamInfo():dynamicMetadata():set("envoy.filters.http.lua.request-filter", "payload", payload)
+    return payload
+end
+
+return request_logger


### PR DESCRIPTION
# HTTP request logging
## Goal
We want to be able to better track what has happened (and when). This PR enables us to do just that - access logs are written to stdout.

## Example: Command injection (via proxy-service)
Command executed:

```bash
$ ug-exploit cmd-inject-proxy "echo test"
```

The envoy-proxy logs can then for example be retrieved as follows:

```bash
$ kubectl -n unguard logs <name of envoy proxy pod>
```

Matching log line (formatted for better readability):

```json
{
    "response_code": 500,
    "downstream_remote_address": "...",
    "timestamp": "2023-11-15T13:48:12.118Z",
    "payload": "imgurl=example.com+%26%26+echo+test+%23",
    "content_type": "application/x-www-form-urlencoded",
    "hostname": "unguard-envoy-proxy-6fcbb8ddf4-92b9m",
    "message": "",
    "upstream_remote_address": "...",
    "user_agent": "python-requests/2.28.2",
    "original_path": "/ui/post",
    "response_code_details": "via_upstream"
}
```

As can be seen in the log line above, the command we've attempted to inject (`echo test`) has been logged as well as the time stamp, the content type of the request etc.