### PR TITLE
:bug: fix(build): specify platform for containers not working on arm

### DIFF
--- a/src/envoy-proxy/Dockerfile
+++ b/src/envoy-proxy/Dockerfile
@@ -1,4 +1,4 @@
-FROM envoyproxy/envoy:v1.23.0
+FROM --platform=linux/amd64 envoyproxy/envoy:v1.23.0
 
 RUN apt-get update && \
     apt-get install -y curl python3 python3-pip && \

--- a/src/frontend/Dockerfile
+++ b/src/frontend/Dockerfile
@@ -1,4 +1,4 @@
-FROM node:14.21.3-slim
+FROM --platform=linux/amd64 node:14.21.3-slim
 
 # Create app directory
 WORKDIR /usr/src/app

--- a/src/user-simulator/Dockerfile
+++ b/src/user-simulator/Dockerfile
@@ -1,5 +1,5 @@
 # based on snippet from https://github.com/puppeteer/puppeteer/blob/main/docs/troubleshooting.md
-FROM node:14.20-slim AS base
+FROM --platform=linux/amd64 node:14.20-slim AS base
 
 # Install latest chrome dev package and fonts to support major charsets (Chinese, Japanese, Arabic, Hebrew, Thai and a few others)
 # Note: this installs the necessary libs to make the bundled version of Chromium that Puppeteer


### PR DESCRIPTION
I was just trying to deploy unguard on an apple silicon mac, some images won't work on arm. Specifying platform fixes any issues though.