### PR TITLE
🐛 fix(release): Fix helm release to bump all service versions

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -70,7 +70,10 @@ jobs:
           commitChange: false
           changes: |
             {
+              "userSimulator.cronJob.jobTemplate.container.image.tag": "${{ env.IMAGE_TAG }}",
               "maliciousLoadGenerator.deployment.container.image.tag": "${{ env.IMAGE_TAG }}",
+              "likeService.deployment.container.image.tag": "${{ env.IMAGE_TAG }}",
+              "paymentService.deployment.container.image.tag": "${{ env.IMAGE_TAG }}",
               "profileService.deployment.container.image.tag": "${{ env.IMAGE_TAG }}",
               "membershipService.deployment.container.image.tag": "${{ env.IMAGE_TAG }}",
               "userAuthService.deployment.container.image.tag": "${{ env.IMAGE_TAG }}",


### PR DESCRIPTION
Fix `user-simulator`, `like-service` and `payment-service` not being correctly updated in helm chart for non-release versions.