### PR TITLE
🐛 fix(chart): switch from ingress annotation to ingressClassName

### DIFF
--- a/chart/templates/ingress.yaml
+++ b/chart/templates/ingress.yaml
@@ -27,6 +27,9 @@ metadata:
   {{- .Values.aws.ingress.annotations | toYaml | nindent 4 }}
   {{ end }}
 spec:
+  {{ if .Values.aws.enabled }}
+  ingressClassName: alb
+  {{ end }}
   rules:
     {{ if .Values.localDev.enabled }}
     - host: unguard.kube

--- a/chart/values.yaml
+++ b/chart/values.yaml
@@ -16,7 +16,6 @@ aws:
   enabled: false
   ingress:
     annotations:
-      kubernetes.io/ingress.class: alb
       alb.ingress.kubernetes.io/target-type: ip
       alb.ingress.kubernetes.io/scheme: internal
       alb.ingress.kubernetes.io/load-balancer-name: "unguard-lb"


### PR DESCRIPTION
The annotation `kubernetes.io/ingress.class: alb` is deprecated based on an error I got when trying to deploy:

> helm install unguard . --values values.yaml --wait --namespace unguard --create-namespace
W0122 08:02:46.163224 663632 warnings.go:70] annotation "kubernetes.io/ingress.class" is deprecated, please use 'spec.ingressClassName' instead

I've updated the specs accordingly so they include the supported `ingressClassName`.
