### PR TITLE
:bug: fix(skaffold): Pin mariadb version to fix skaffold command

### DIFF
--- a/skaffold.yaml
+++ b/skaffold.yaml
@@ -58,6 +58,7 @@ deploy:
       - name: unguard-mariadb
         remoteChart: mariadb
         repo: https://charts.bitnami.com/bitnami
+        version: "11.5.7"
         namespace: unguard
         createNamespace: true
         wait: true # TODO: #22 Might be removed once we have readiness probes


### PR DESCRIPTION
The `skaffold run` command was failing because we did not specify the `version` property for the mariadb release in the `skaffold.yaml`.

Fixed it by specifically setting the version to `11.5.7`, as documented in the [chart/README.md](https://github.com/dynatrace-oss/unguard/blob/main/chart/README.md)

Closes #95 