### PR TITLE
Add exploit-toolkit as a separate workload

### DIFF
--- a/chart/templates/ad-service.yaml
+++ b/chart/templates/ad-service.yaml
@@ -13,67 +13,70 @@ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 See the License for the specific language governing permissions and
 limitations under the License.
 */}}
+
+{{- if eq .Values.unguard.enabled true }}
 apiVersion: v1
 kind: Service
 metadata:
-  name: unguard-{{ .Values.adService.name }}
+  name: unguard-{{ .Values.unguard.adService.name }}
   labels:
-    app.kubernetes.io/name: {{ .Values.adService.name }}
+    app.kubernetes.io/name: {{ .Values.unguard.adService.name }}
     app.kubernetes.io/part-of: unguard
 {{ include "renderLabels" .Values.labels.common | indent 4 }}
 spec:
-  type: {{ .Values.adService.service.type }}
+  type: {{ .Values.unguard.adService.service.type }}
   selector:
-    app.kubernetes.io/name: {{ .Values.adService.name }}
+    app.kubernetes.io/name: {{ .Values.unguard.adService.name }}
     app.kubernetes.io/part-of: unguard
   ports:
- {{- .Values.adService.service.ports | toYaml | nindent 4 }}
+ {{- .Values.unguard.adService.service.ports | toYaml | nindent 4 }}
 
 ---
 apiVersion: apps/v1
 kind: Deployment
 metadata:
-  name: unguard-{{ .Values.adService.name }}
+  name: unguard-{{ .Values.unguard.adService.name }}
   labels:
-    app.kubernetes.io/name: {{ .Values.adService.name }}
+    app.kubernetes.io/name: {{ .Values.unguard.adService.name }}
     app.kubernetes.io/part-of: unguard
     {{ include "renderLabels" .Values.labels.common }}
 spec:
   selector:
     matchLabels:
-      app.kubernetes.io/name: {{ .Values.adService.name }}
+      app.kubernetes.io/name: {{ .Values.unguard.adService.name }}
       app.kubernetes.io/part-of: unguard
   strategy:
-    type: {{ .Values.adService.deployment.strategy.type }}
+    type: {{ .Values.unguard.adService.deployment.strategy.type }}
   template:
     metadata:
       labels:
-        app.kubernetes.io/name: {{ .Values.adService.name }}
+        app.kubernetes.io/name: {{ .Values.unguard.adService.name }}
         app.kubernetes.io/part-of: unguard
 {{ include "renderLabels" .Values.labels.common | indent 8 }}
     spec:
       containers:
-        - name: {{ .Values.adService.name }}
-          image: {{ .Values.adService.deployment.container.image.repository }}:{{ .Values.adService.deployment.container.image.tag }}
-          imagePullPolicy: {{ .Values.adService.deployment.container.image.pullPolicy }}
+        - name: {{ .Values.unguard.adService.name }}
+          image: {{ .Values.unguard.adService.deployment.container.image.repository }}:{{ .Values.unguard.adService.deployment.container.image.tag }}
+          imagePullPolicy: {{ .Values.unguard.adService.deployment.container.image.pullPolicy }}
           ports:
-            - containerPort: {{ .Values.adService.deployment.container.ports.containerPort }}
+            - containerPort: {{ .Values.unguard.adService.deployment.container.ports.containerPort }}
           env:
             - name: ASPNETCORE_ENVIRONMENT
-              value: {{ quote .Values.adService.deployment.container.env.ASPNETCORE_ENVIRONMENT }}
+              value: {{ quote .Values.unguard.adService.deployment.container.env.ASPNETCORE_ENVIRONMENT }}
             - name: SERVER_PORT
-              value: {{ quote .Values.adService.deployment.container.env.SERVER_PORT }}
+              value: {{ quote .Values.unguard.adService.deployment.container.env.SERVER_PORT }}
             - name: API_PATH
-              value: {{ quote .Values.adService.deployment.container.env.API_PATH }}
+              value: {{ quote .Values.unguard.adService.deployment.container.env.API_PATH }}
             - name: USER_AUTH_SERVICE_ADDRESS
-              value: {{ quote .Values.adService.deployment.container.env.USER_AUTH_SERVICE_ADDRESS }}
+              value: {{ quote .Values.unguard.adService.deployment.container.env.USER_AUTH_SERVICE_ADDRESS }}
             - name: JAEGER_SERVICE_NAME
-              value: {{ quote (printf "unguard-%s" .Values.adService.name) }}
+              value: {{ quote (printf "unguard-%s" .Values.unguard.adService.name) }}
             - name: JAEGER_AGENT_HOST
-              value: {{ quote (printf "%s-%s" .Values.jaeger.name .Values.adService.deployment.container.env.JAEGER_AGENT_HOST) }}
+              value: {{ quote (printf "%s-%s" .Values.jaeger.name .Values.unguard.adService.deployment.container.env.JAEGER_AGENT_HOST) }}
             - name: JAEGER_SAMPLER_TYPE
-              value: {{ quote .Values.adService.deployment.container.env.JAEGER_SAMPLER_TYPE }}
+              value: {{ quote .Values.unguard.adService.deployment.container.env.JAEGER_SAMPLER_TYPE }}
             - name: JAEGER_SAMPLER_PARAM
-              value: {{ quote .Values.adService.deployment.container.env.JAEGER_SAMPLER_PARAM }}
+              value: {{ quote .Values.unguard.adService.deployment.container.env.JAEGER_SAMPLER_PARAM }}
             - name: JAEGER_DISABLED
-              value: {{ quote .Values.adService.deployment.container.env.JAEGER_DISABLED }}
+              value: {{ quote .Values.unguard.adService.deployment.container.env.JAEGER_DISABLED }}
+{{- end }}

--- a/chart/templates/envoy-proxy.yaml
+++ b/chart/templates/envoy-proxy.yaml
@@ -14,52 +14,54 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */}}
 
+{{- if eq .Values.unguard.enabled true }}
 apiVersion: v1
 kind: Service
 metadata:
-  name: unguard-{{ .Values.envoyProxy.name }}
+  name: unguard-{{ .Values.unguard.envoyProxy.name }}
   labels:
-    app.kubernetes.io/name: {{ .Values.envoyProxy.name }}
+    app.kubernetes.io/name: {{ .Values.unguard.envoyProxy.name }}
     app.kubernetes.io/part-of: unguard
 {{ include "renderLabels" .Values.labels.common | indent 4 }}
 spec:
   {{ if .Values.aws.enabled }}
   type: NodePort
   {{ else }}
-  type: {{ .Values.envoyProxy.service.type }}
+  type: {{ .Values.unguard.envoyProxy.service.type }}
   {{ end }}
   selector:
-    app.kubernetes.io/name: {{ .Values.envoyProxy.name }}
+    app.kubernetes.io/name: {{ .Values.unguard.envoyProxy.name }}
     app.kubernetes.io/part-of: unguard
   ports:
- {{- .Values.envoyProxy.service.ports | toYaml | nindent 4 }}
+ {{- .Values.unguard.envoyProxy.service.ports | toYaml | nindent 4 }}
 
 ---
 apiVersion: apps/v1
 kind: Deployment
 metadata:
-  name: unguard-{{ .Values.envoyProxy.name }}
+  name: unguard-{{ .Values.unguard.envoyProxy.name }}
   labels:
-    app.kubernetes.io/name: {{ .Values.envoyProxy.name }}
+    app.kubernetes.io/name: {{ .Values.unguard.envoyProxy.name }}
     app.kubernetes.io/part-of: unguard
 {{ include "renderLabels" .Values.labels.common | indent 4 }}
 spec:
   selector:
     matchLabels:
-      app.kubernetes.io/name: {{ .Values.envoyProxy.name }}
+      app.kubernetes.io/name: {{ .Values.unguard.envoyProxy.name }}
       app.kubernetes.io/part-of: unguard
   strategy:
-    type: {{ .Values.envoyProxy.deployment.strategy.type }}
+    type: {{ .Values.unguard.envoyProxy.deployment.strategy.type }}
   template:
     metadata:
       labels:
-        app.kubernetes.io/name: {{ .Values.envoyProxy.name }}
+        app.kubernetes.io/name: {{ .Values.unguard.envoyProxy.name }}
         app.kubernetes.io/part-of: unguard
 {{ include "renderLabels" .Values.labels.common | indent 8 }}
     spec:
       containers:
-        - name: {{ .Values.envoyProxy.name }}
-          image: {{ .Values.envoyProxy.deployment.container.image.repository }}:{{ .Values.envoyProxy.deployment.container.image.tag }}
-          imagePullPolicy: {{ .Values.envoyProxy.deployment.container.image.pullPolicy }}
+        - name: {{ .Values.unguard.envoyProxy.name }}
+          image: {{ .Values.unguard.envoyProxy.deployment.container.image.repository }}:{{ .Values.unguard.envoyProxy.deployment.container.image.tag }}
+          imagePullPolicy: {{ .Values.unguard.envoyProxy.deployment.container.image.pullPolicy }}
           ports:
-            {{- .Values.envoyProxy.deployment.container.ports | toYaml | nindent 12 }}
+            {{- .Values.unguard.envoyProxy.deployment.container.ports | toYaml | nindent 12 }}
+{{- end }}

--- a/chart/templates/exploit-toolkit.yaml
+++ b/chart/templates/exploit-toolkit.yaml
@@ -1,0 +1,53 @@
+{{- /*
+Copyright 2025 Dynatrace LLC
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/}}
+
+{{- if eq .Values.exploit_toolkit.enabled true }}
+apiVersion: batch/v1
+kind: CronJob
+metadata:
+  name: exploit-toolkit
+spec:
+  schedule: {{ .Values.exploit_toolkit.cronjob.schedule | quote }}
+  jobTemplate:
+    spec:
+      template:
+        spec:
+          containers:
+          - name: exploit-toolkit
+            image: {{ .Values.exploit_toolkit.cronjob.container.image.repository }}:{{ .Values.exploit_toolkit.cronjob.container.image.tag }}
+            imagePullPolicy: {{ .Values.exploit_toolkit.cronjob.container.imagePullPolicy }}
+            command: ["/bin/bash"]
+            args: ["/opt/ug-exploit/exploit.sh"]
+            volumeMounts:
+            - name: exploits
+              mountPath: /opt/ug-exploit/exploit.sh
+              subPath: exploit.sh
+          restartPolicy: Never
+          volumes:
+          - name: exploits
+            configMap:
+              name: exploit-toolkit
+              defaultMode: 0777
+
+---
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: exploit-toolkit
+data:
+  exploit.sh: |
+    {{ .Values.exploit_toolkit.script }}
+{{- end }}

--- a/chart/templates/frontend.yaml
+++ b/chart/templates/frontend.yaml
@@ -14,85 +14,87 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */}}
 
+{{- if eq .Values.unguard.enabled true }}
 apiVersion: v1
 kind: Service
 metadata:
-  name: unguard-{{ .Values.frontend.name }}
+  name: unguard-{{ .Values.unguard.frontend.name }}
   labels:
-    app.kubernetes.io/name: {{ .Values.frontend.name }}
+    app.kubernetes.io/name: {{ .Values.unguard.frontend.name }}
     app.kubernetes.io/part-of: unguard
 {{ include "renderLabels" .Values.labels.common | indent 4 }}
 spec:
-  type: {{ .Values.frontend.service.type }}
+  type: {{ .Values.unguard.frontend.service.type }}
   selector:
-    app.kubernetes.io/name: {{ .Values.frontend.name }}
+    app.kubernetes.io/name: {{ .Values.unguard.frontend.name }}
     app.kubernetes.io/part-of: unguard
   ports:
- {{- .Values.frontend.service.ports | toYaml | nindent 4 }}
+ {{- .Values.unguard.frontend.service.ports | toYaml | nindent 4 }}
 
 ---
 apiVersion: apps/v1
 kind: Deployment
 metadata:
-  name: unguard-{{ .Values.frontend.name }}
+  name: unguard-{{ .Values.unguard.frontend.name }}
   labels:
-    app.kubernetes.io/name: {{ .Values.frontend.name }}
+    app.kubernetes.io/name: {{ .Values.unguard.frontend.name }}
     app.kubernetes.io/part-of: unguard
 {{ include "renderLabels" .Values.labels.common | indent 4 }}
 spec:
   selector:
     matchLabels:
-      app.kubernetes.io/name: {{ .Values.frontend.name }}
+      app.kubernetes.io/name: {{ .Values.unguard.frontend.name }}
       app.kubernetes.io/part-of: unguard
   strategy:
-    type: {{ .Values.frontend.deployment.strategy.type }}
+    type: {{ .Values.unguard.frontend.deployment.strategy.type }}
   template:
     metadata:
       labels:
-        app.kubernetes.io/name: {{ .Values.frontend.name }}
+        app.kubernetes.io/name: {{ .Values.unguard.frontend.name }}
         app.kubernetes.io/part-of: unguard
 {{ include "renderLabels" .Values.labels.common | indent 8 }}
     spec:
       containers:
-        - name: {{ .Values.frontend.name }}
-          image: {{ .Values.frontend.deployment.container.image.repository }}:{{ .Values.frontend.deployment.container.image.tag }}
-          imagePullPolicy: {{ .Values.frontend.deployment.container.image.pullPolicy }}
+        - name: {{ .Values.unguard.frontend.name }}
+          image: {{ .Values.unguard.frontend.deployment.container.image.repository }}:{{ .Values.unguard.frontend.deployment.container.image.tag }}
+          imagePullPolicy: {{ .Values.unguard.frontend.deployment.container.image.pullPolicy }}
           ports:
-            - containerPort: {{ .Values.frontend.deployment.container.ports.containerPort }}
+            - containerPort: {{ .Values.unguard.frontend.deployment.container.ports.containerPort }}
           env:
             - name: MICROBLOG_SERVICE_ADDRESS
-              value: {{ quote .Values.frontend.deployment.container.env.MICROBLOG_SERVICE_ADDRESS }}
+              value: {{ quote .Values.unguard.frontend.deployment.container.env.MICROBLOG_SERVICE_ADDRESS }}
             - name: PROXY_SERVICE_ADDRESS
-              value: {{ quote .Values.frontend.deployment.container.env.PROXY_SERVICE_ADDRESS }}
+              value: {{ quote .Values.unguard.frontend.deployment.container.env.PROXY_SERVICE_ADDRESS }}
             - name: USER_AUTH_SERVICE_ADDRESS
-              value: {{ quote .Values.frontend.deployment.container.env.USER_AUTH_SERVICE_ADDRESS }}
+              value: {{ quote .Values.unguard.frontend.deployment.container.env.USER_AUTH_SERVICE_ADDRESS }}
             - name: AD_SERVICE_ADDRESS
-              value: {{ quote .Values.frontend.deployment.container.env.AD_SERVICE_ADDRESS }}
+              value: {{ quote .Values.unguard.frontend.deployment.container.env.AD_SERVICE_ADDRESS }}
             - name: STATUS_SERVICE_ADDRESS
-              value: {{ quote .Values.frontend.deployment.container.env.STATUS_SERVICE_ADDRESS }}
+              value: {{ quote .Values.unguard.frontend.deployment.container.env.STATUS_SERVICE_ADDRESS }}
             - name: MEMBERSHIP_SERVICE_ADDRESS
-              value: {{ quote .Values.frontend.deployment.container.env.MEMBERSHIP_SERVICE_ADDRESS }}
+              value: {{ quote .Values.unguard.frontend.deployment.container.env.MEMBERSHIP_SERVICE_ADDRESS }}
             - name: PROFILE_SERVICE_ADDRESS
-              value: {{ quote .Values.frontend.deployment.container.env.PROFILE_SERVICE_ADDRESS }}
+              value: {{ quote .Values.unguard.frontend.deployment.container.env.PROFILE_SERVICE_ADDRESS }}
             - name: LIKE_SERVICE_ADDRES
-              value: {{ quote .Values.frontend.deployment.container.env.LIKE_SERVICE_ADDRES }}
+              value: {{ quote .Values.unguard.frontend.deployment.container.env.LIKE_SERVICE_ADDRES }}
             - name: PAYMENT_SERVICE_ADDRESS
-              value: {{ quote .Values.frontend.deployment.container.env.PAYMENT_SERVICE_ADDRESS }}
+              value: {{ quote .Values.unguard.frontend.deployment.container.env.PAYMENT_SERVICE_ADDRESS }}
             - name: FRONTEND_BASE_PATH
-              value: {{ quote .Values.frontend.deployment.container.env.FRONTEND_BASE_PATH }}
+              value: {{ quote .Values.unguard.frontend.deployment.container.env.FRONTEND_BASE_PATH }}
             - name: AD_SERVICE_BASE_PATH
-              value: {{ quote .Values.frontend.deployment.container.env.AD_SERVICE_BASE_PATH }}
+              value: {{ quote .Values.unguard.frontend.deployment.container.env.AD_SERVICE_BASE_PATH }}
             - name: MEMBERSHIP_SERVICE_BASE_PATH
-              value: {{ quote .Values.frontend.deployment.container.env.MEMBERSHIP_SERVICE_BASE_PATH }}
+              value: {{ quote .Values.unguard.frontend.deployment.container.env.MEMBERSHIP_SERVICE_BASE_PATH }}
             - name: STATUS_SERVICE_BASE_PATH
-              value: {{ quote .Values.frontend.deployment.container.env.STATUS_SERVICE_BASE_PATH }}
+              value: {{ quote .Values.unguard.frontend.deployment.container.env.STATUS_SERVICE_BASE_PATH }}
             - name: JAEGER_SERVICE_NAME
-              value: {{ quote (printf "unguard-%s" .Values.frontend.name) }}
+              value: {{ quote (printf "unguard-%s" .Values.unguard.frontend.name) }}
             - name: JAEGER_AGENT_HOST
-              value: {{ quote (printf "%s-%s" .Values.jaeger.name .Values.frontend.deployment.container.env.JAEGER_AGENT_HOST) }}
+              value: {{ quote (printf "%s-%s" .Values.jaeger.name .Values.unguard.frontend.deployment.container.env.JAEGER_AGENT_HOST) }}
             - name: JAEGER_SAMPLER_TYPE
-              value: {{ quote .Values.frontend.deployment.container.env.JAEGER_SAMPLER_TYPE }}
+              value: {{ quote .Values.unguard.frontend.deployment.container.env.JAEGER_SAMPLER_TYPE }}
             - name: JAEGER_SAMPLER_PARAM
-              value: {{ quote .Values.frontend.deployment.container.env.JAEGER_SAMPLER_PARAM }}
+              value: {{ quote .Values.unguard.frontend.deployment.container.env.JAEGER_SAMPLER_PARAM }}
             - name: JAEGER_DISABLED
-              value: {{ quote .Values.frontend.deployment.container.env.JAEGER_DISABLED }}
+              value: {{ quote .Values.unguard.frontend.deployment.container.env.JAEGER_DISABLED }}
+{{- end }}

--- a/chart/templates/ingress.yaml
+++ b/chart/templates/ingress.yaml
@@ -13,6 +13,8 @@ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 See the License for the specific language governing permissions and
 limitations under the License.
 */}}
+
+{{- if eq .Values.unguard.enabled true }}
 {{- if or .Values.localDev.enabled .Values.aws.enabled -}}
 apiVersion: networking.k8s.io/v1
 kind: Ingress
@@ -55,4 +57,5 @@ spec:
                 name: unguard-envoy-proxy
                 port:
                   number: 8080
+{{ end }}
 {{ end }}

--- a/chart/templates/like-service.yaml
+++ b/chart/templates/like-service.yaml
@@ -13,76 +13,79 @@ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 See the License for the specific language governing permissions and
 limitations under the License.
 */}}
+
+{{- if eq .Values.unguard.enabled true }}
 apiVersion: v1
 kind: Service
 metadata:
-  name: unguard-{{ .Values.likeService.name }}
+  name: unguard-{{ .Values.unguard.likeService.name }}
   labels:
-    app.kubernetes.io/name: {{ .Values.likeService.name }}
+    app.kubernetes.io/name: {{ .Values.unguard.likeService.name }}
     app.kubernetes.io/part-of: unguard
 {{ include "renderLabels" .Values.labels.common | indent 4 }}
 spec:
-  type: {{ .Values.likeService.service.type }}
+  type: {{ .Values.unguard.likeService.service.type }}
   selector:
-    app.kubernetes.io/name: {{ .Values.likeService.name }}
+    app.kubernetes.io/name: {{ .Values.unguard.likeService.name }}
     app.kubernetes.io/part-of: unguard
   ports:
- {{- .Values.likeService.service.ports | toYaml | nindent 4 }}
+ {{- .Values.unguard.likeService.service.ports | toYaml | nindent 4 }}
 
 ---
 apiVersion: apps/v1
 kind: Deployment
 metadata:
-  name: unguard-{{ .Values.likeService.name }}
+  name: unguard-{{ .Values.unguard.likeService.name }}
   labels:
-    app.kubernetes.io/name: {{ .Values.likeService.name }}
+    app.kubernetes.io/name: {{ .Values.unguard.likeService.name }}
     app.kubernetes.io/part-of: unguard
 {{ include "renderLabels" .Values.labels.common | indent 4 }}
 spec:
   selector:
     matchLabels:
-      app.kubernetes.io/name: {{ .Values.likeService.name }}
+      app.kubernetes.io/name: {{ .Values.unguard.likeService.name }}
       app.kubernetes.io/part-of: unguard
   strategy:
-    type: {{ .Values.likeService.deployment.strategy.type }}
+    type: {{ .Values.unguard.likeService.deployment.strategy.type }}
   template:
     metadata:
       labels:
-        app.kubernetes.io/name: {{ .Values.likeService.name }}
+        app.kubernetes.io/name: {{ .Values.unguard.likeService.name }}
         app.kubernetes.io/part-of: unguard
 {{ include "renderLabels" .Values.labels.common | indent 8 }}
     spec:
       containers:
-        - name: {{ .Values.likeService.name }}
-          image: {{ .Values.likeService.deployment.container.image.repository }}:{{ .Values.likeService.deployment.container.image.tag }}
-          imagePullPolicy: {{ .Values.likeService.deployment.container.image.pullPolicy }}
+        - name: {{ .Values.unguard.likeService.name }}
+          image: {{ .Values.unguard.likeService.deployment.container.image.repository }}:{{ .Values.unguard.likeService.deployment.container.image.tag }}
+          imagePullPolicy: {{ .Values.unguard.likeService.deployment.container.image.pullPolicy }}
           ports:
-            - containerPort: {{ .Values.likeService.deployment.container.ports.containerPort }}
+            - containerPort: {{ .Values.unguard.likeService.deployment.container.ports.containerPort }}
           env:
             - name: SERVER_PORT
-              value: {{ quote .Values.likeService.deployment.container.env.SERVER_PORT }}
+              value: {{ quote .Values.unguard.likeService.deployment.container.env.SERVER_PORT }}
             - name: API_PATH
-              value: {{ quote .Values.likeService.deployment.container.env.API_PATH }}
+              value: {{ quote .Values.unguard.likeService.deployment.container.env.API_PATH }}
             - name: USER_AUTH_SERVICE_ADDRESS
-              value: {{ quote .Values.likeService.deployment.container.env.USER_AUTH_SERVICE_ADDRESS }}
+              value: {{ quote .Values.unguard.likeService.deployment.container.env.USER_AUTH_SERVICE_ADDRESS }}
             - name: DB_HOST
-              value: {{ tpl .Values.likeService.deployment.container.env.DB_HOST . }}
+              value: {{ tpl .Values.unguard.likeService.deployment.container.env.DB_HOST . }}
             - name: DB_PORT
-              value: {{ tpl .Values.likeService.deployment.container.env.DB_PORT . | quote }}
+              value: {{ tpl .Values.unguard.likeService.deployment.container.env.DB_PORT . | quote }}
             - name: MARIADB_PASSWORD
               valueFrom:
                 secretKeyRef:
-                  name: {{ tpl .Values.likeService.deployment.container.env.MARIADB_PASSWORD.secretKeyRef.name . }}
-                  key: {{ tpl .Values.likeService.deployment.container.env.MARIADB_PASSWORD.secretKeyRef.key . }}
+                  name: {{ tpl .Values.unguard.likeService.deployment.container.env.MARIADB_PASSWORD.secretKeyRef.name . }}
+                  key: {{ tpl .Values.unguard.likeService.deployment.container.env.MARIADB_PASSWORD.secretKeyRef.key . }}
             - name: JAEGER_SERVICE_NAME
-              value: {{ quote (printf "unguard-%s" .Values.likeService.name) }}
+              value: {{ quote (printf "unguard-%s" .Values.unguard.likeService.name) }}
             {{ if .Values.tracing.enabled }}
             - name: JAEGER_COLLECTOR_HOST
-              value: {{ quote (printf "%s-%s" .Values.jaeger.name .Values.likeService.deployment.container.env.JAEGER_COLLECTOR_HOST) }}
+              value: {{ quote (printf "%s-%s" .Values.jaeger.name .Values.unguard.likeService.deployment.container.env.JAEGER_COLLECTOR_HOST) }}
             - name: JAEGER_PORT
-              value: {{ quote .Values.likeService.deployment.container.env.JAEGER_PORT }}
+              value: {{ quote .Values.unguard.likeService.deployment.container.env.JAEGER_PORT }}
             - name: SERVICE_NAME
-              value: {{ quote .Values.likeService.deployment.container.env.SERVICE_NAME }}
+              value: {{ quote .Values.unguard.likeService.deployment.container.env.SERVICE_NAME }}
             - name: JAEGER_DISABLED
-              value: {{ quote .Values.likeService.deployment.container.env.JAEGER_DISABLED }}
+              value: {{ quote .Values.unguard.likeService.deployment.container.env.JAEGER_DISABLED }}
             {{ end }}
+{{ end }}

--- a/chart/templates/malicious-load-generator.yaml
+++ b/chart/templates/malicious-load-generator.yaml
@@ -13,46 +13,49 @@ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 See the License for the specific language governing permissions and
 limitations under the License.
 */}}
-{{ if .Values.maliciousLoadGenerator.enabled }}
+
+{{- if eq .Values.unguard.enabled true }}
+{{ if .Values.unguard.maliciousLoadGenerator.enabled }}
 apiVersion: apps/v1
 kind: Deployment
 metadata:
-  name: unguard-{{ .Values.maliciousLoadGenerator.name }}
+  name: unguard-{{ .Values.unguard.maliciousLoadGenerator.name }}
   labels:
-    app.kubernetes.io/name: {{ .Values.maliciousLoadGenerator.name }}
+    app.kubernetes.io/name: {{ .Values.unguard.maliciousLoadGenerator.name }}
     app.kubernetes.io/part-of: unguard
 {{ include "renderLabels" .Values.labels.common | indent 4 }}
 spec:
   selector:
     matchLabels:
-      app.kubernetes.io/name: {{ .Values.maliciousLoadGenerator.name }}
+      app.kubernetes.io/name: {{ .Values.unguard.maliciousLoadGenerator.name }}
       app.kubernetes.io/part-of: unguard
   strategy:
-    type: {{ .Values.maliciousLoadGenerator.deployment.strategy.type }}
+    type: {{ .Values.unguard.maliciousLoadGenerator.deployment.strategy.type }}
   template:
     metadata:
       labels:
-        app.kubernetes.io/name: {{ .Values.maliciousLoadGenerator.name }}
+        app.kubernetes.io/name: {{ .Values.unguard.maliciousLoadGenerator.name }}
         app.kubernetes.io/part-of: unguard
 {{ include "renderLabels" .Values.labels.common | indent 8 }}
     spec:
-      terminationGracePeriodSeconds: {{ .Values.maliciousLoadGenerator.deployment.terminationGracePeriodSeconds }}
-      restartPolicy: {{ .Values.maliciousLoadGenerator.deployment.restartPolicy }}
+      terminationGracePeriodSeconds: {{ .Values.unguard.maliciousLoadGenerator.deployment.terminationGracePeriodSeconds }}
+      restartPolicy: {{ .Values.unguard.maliciousLoadGenerator.deployment.restartPolicy }}
       containers:
-        - name: {{ .Values.maliciousLoadGenerator.name }}
-          image: {{ .Values.maliciousLoadGenerator.deployment.container.image.repository }}:{{ .Values.maliciousLoadGenerator.deployment.container.image.tag }}
-          imagePullPolicy: {{ .Values.maliciousLoadGenerator.deployment.container.image.pullPolicy }}
+        - name: {{ .Values.unguard.maliciousLoadGenerator.name }}
+          image: {{ .Values.unguard.maliciousLoadGenerator.deployment.container.image.repository }}:{{ .Values.unguard.maliciousLoadGenerator.deployment.container.image.tag }}
+          imagePullPolicy: {{ .Values.unguard.maliciousLoadGenerator.deployment.container.image.pullPolicy }}
           env: # could add here run time as well
             - name: FRONTEND_ADDR
-              value: {{ quote .Values.maliciousLoadGenerator.deployment.container.env.FRONTEND_ADDR }}
+              value: {{ quote .Values.unguard.maliciousLoadGenerator.deployment.container.env.FRONTEND_ADDR }}
             - name: USERS # USERS and WAIT_TIME (in seconds) are optional, default value for USERS = 1, WAIT_TIME = 1800
-              value: {{ quote .Values.maliciousLoadGenerator.deployment.container.env.USERS }}
+              value: {{ quote .Values.unguard.maliciousLoadGenerator.deployment.container.env.USERS }}
             - name: WAIT_TIME
-              value: {{ quote .Values.maliciousLoadGenerator.deployment.container.env.WAIT_TIME }}
+              value: {{ quote .Values.unguard.maliciousLoadGenerator.deployment.container.env.WAIT_TIME }}
       initContainers:
         - name: wait-for-frontend
           image: curlimages/curl
           command: [ "/bin/sh", "-c" ]
           # TODO: #22 Replace this endpoint with a proper health check endpoint
           args: [ 'while [ $(curl -ksw "%{http_code}" "http://unguard-frontend:80/ui/img/logo.svg" -o /dev/null) -ne 200 ]; do sleep 5; echo "health check failed . Waiting for the service..."; done' ]
+{{ end }}
 {{ end }}

--- a/chart/templates/membership-service.yaml
+++ b/chart/templates/membership-service.yaml
@@ -14,61 +14,63 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */}}
 
+{{- if eq .Values.unguard.enabled true }}
 apiVersion: v1
 kind: Service
 metadata:
-  name: unguard-{{ .Values.membershipService.name }}
+  name: unguard-{{ .Values.unguard.membershipService.name }}
   labels:
-    app.kubernetes.io/name: {{ .Values.membershipService.name }}
+    app.kubernetes.io/name: {{ .Values.unguard.membershipService.name }}
     app.kubernetes.io/part-of: unguard
 {{ include "renderLabels" .Values.labels.common | indent 4 }}
 spec:
-  type: {{ .Values.membershipService.service.type }}
+  type: {{ .Values.unguard.membershipService.service.type }}
   selector:
-    app.kubernetes.io/name: {{ .Values.membershipService.name }}
+    app.kubernetes.io/name: {{ .Values.unguard.membershipService.name }}
     app.kubernetes.io/part-of: unguard
   ports:
- {{- .Values.membershipService.service.ports | toYaml | nindent 4 }}
+ {{- .Values.unguard.membershipService.service.ports | toYaml | nindent 4 }}
 ---
 apiVersion: apps/v1
 kind: Deployment
 metadata:
-  name: unguard-{{ .Values.membershipService.name }}
+  name: unguard-{{ .Values.unguard.membershipService.name }}
   labels:
-    app.kubernetes.io/name: {{ .Values.membershipService.name }}
+    app.kubernetes.io/name: {{ .Values.unguard.membershipService.name }}
     app.kubernetes.io/part-of: unguard
 {{ include "renderLabels" .Values.labels.common | indent 4 }}
 spec:
   selector:
     matchLabels:
-      app.kubernetes.io/name: {{ .Values.membershipService.name }}
+      app.kubernetes.io/name: {{ .Values.unguard.membershipService.name }}
       app.kubernetes.io/part-of: unguard
   strategy:
-    type: {{ .Values.membershipService.deployment.strategy.type }}
+    type: {{ .Values.unguard.membershipService.deployment.strategy.type }}
   template:
     metadata:
       labels:
-        app.kubernetes.io/name: {{ .Values.membershipService.name }}
+        app.kubernetes.io/name: {{ .Values.unguard.membershipService.name }}
         app.kubernetes.io/part-of: unguard
 {{ include "renderLabels" .Values.labels.common | indent 8 }}
     spec:
       containers:
-        - name: {{ .Values.membershipService.name }}
-          image: {{ .Values.membershipService.deployment.container.image.repository }}:{{ .Values.membershipService.deployment.container.image.tag }}
-          imagePullPolicy: {{ .Values.membershipService.deployment.container.image.pullPolicy }}
+        - name: {{ .Values.unguard.membershipService.name }}
+          image: {{ .Values.unguard.membershipService.deployment.container.image.repository }}:{{ .Values.unguard.membershipService.deployment.container.image.tag }}
+          imagePullPolicy: {{ .Values.unguard.membershipService.deployment.container.image.pullPolicy }}
           ports:
-            - containerPort: {{ .Values.membershipService.deployment.container.ports.containerPort }}
+            - containerPort: {{ .Values.unguard.membershipService.deployment.container.ports.containerPort }}
           env:
             - name: ASPNETCORE_ENVIRONMENT
-              value: {{ quote .Values.membershipService.deployment.container.env.ASPNETCORE_ENVIRONMENT }}
+              value: {{ quote .Values.unguard.membershipService.deployment.container.env.ASPNETCORE_ENVIRONMENT }}
             - name: SERVER_PORT
-              value: {{ quote .Values.membershipService.deployment.container.env.SERVER_PORT }}
+              value: {{ quote .Values.unguard.membershipService.deployment.container.env.SERVER_PORT }}
             - name: API_PATH
-              value: {{ quote .Values.membershipService.deployment.container.env.API_PATH }}
+              value: {{ quote .Values.unguard.membershipService.deployment.container.env.API_PATH }}
             - name: MARIADB_SERVICE
-              value: {{ tpl .Values.membershipService.deployment.container.env.MARIADB_SERVICE . | quote }}
+              value: {{ tpl .Values.unguard.membershipService.deployment.container.env.MARIADB_SERVICE . | quote }}
             - name: MARIADB_PASSWORD
               valueFrom:
                 secretKeyRef:
-                  name: {{ tpl .Values.membershipService.deployment.container.env.MARIADB_PASSWORD.secretKeyRef.name . }}
-                  key: {{ tpl .Values.membershipService.deployment.container.env.MARIADB_PASSWORD.secretKeyRef.key . }}
+                  name: {{ tpl .Values.unguard.membershipService.deployment.container.env.MARIADB_PASSWORD.secretKeyRef.name . }}
+                  key: {{ tpl .Values.unguard.membershipService.deployment.container.env.MARIADB_PASSWORD.secretKeyRef.key . }}
+{{ end }}

--- a/chart/templates/microblog-service.yaml
+++ b/chart/templates/microblog-service.yaml
@@ -14,65 +14,67 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */}}
 
+{{- if eq .Values.unguard.enabled true }}
 apiVersion: v1
 kind: Service
 metadata:
-  name: unguard-{{ .Values.microblogService.name }}
+  name: unguard-{{ .Values.unguard.microblogService.name }}
   labels:
-    app.kubernetes.io/name: {{ .Values.microblogService.name }}
+    app.kubernetes.io/name: {{ .Values.unguard.microblogService.name }}
     app.kubernetes.io/part-of: unguard
 {{ include "renderLabels" .Values.labels.common | indent 4 }}
 spec:
-  type: {{ .Values.microblogService.service.type }}
+  type: {{ .Values.unguard.microblogService.service.type }}
   selector:
-    app.kubernetes.io/name: {{ .Values.microblogService.name }}
+    app.kubernetes.io/name: {{ .Values.unguard.microblogService.name }}
     app.kubernetes.io/part-of: unguard
   ports:
- {{- .Values.microblogService.service.ports | toYaml | nindent 4 }}
+ {{- .Values.unguard.microblogService.service.ports | toYaml | nindent 4 }}
 
 ---
 apiVersion: apps/v1
 kind: Deployment
 metadata:
-  name: unguard-{{ .Values.microblogService.name }}
+  name: unguard-{{ .Values.unguard.microblogService.name }}
   labels:
-    app.kubernetes.io/name: {{ .Values.microblogService.name }}
+    app.kubernetes.io/name: {{ .Values.unguard.microblogService.name }}
     app.kubernetes.io/part-of: unguard
 {{ include "renderLabels" .Values.labels.common | indent 4 }}
 spec:
   selector:
     matchLabels:
-      app.kubernetes.io/name: {{ .Values.microblogService.name }}
+      app.kubernetes.io/name: {{ .Values.unguard.microblogService.name }}
       app.kubernetes.io/part-of: unguard
   strategy:
-    type: {{ .Values.microblogService.deployment.strategy.type }}
+    type: {{ .Values.unguard.microblogService.deployment.strategy.type }}
   template:
     metadata:
       labels:
-        app.kubernetes.io/name: {{ .Values.microblogService.name }}
+        app.kubernetes.io/name: {{ .Values.unguard.microblogService.name }}
         app.kubernetes.io/part-of: unguard
 {{ include "renderLabels" .Values.labels.common | indent 8 }}
     spec:
       containers:
-        - name: {{ .Values.microblogService.name }}
-          image: {{ .Values.microblogService.deployment.container.image.repository }}:{{ .Values.microblogService.deployment.container.image.tag }}
-          imagePullPolicy: {{ .Values.microblogService.deployment.container.image.pullPolicy }}
+        - name: {{ .Values.unguard.microblogService.name }}
+          image: {{ .Values.unguard.microblogService.deployment.container.image.repository }}:{{ .Values.unguard.microblogService.deployment.container.image.tag }}
+          imagePullPolicy: {{ .Values.unguard.microblogService.deployment.container.image.pullPolicy }}
           ports:
-            - containerPort: {{ .Values.microblogService.deployment.container.ports.containerPort }}
+            - containerPort: {{ .Values.unguard.microblogService.deployment.container.ports.containerPort }}
           env:
             - name: SERVER_PORT
-              value: {{ quote .Values.microblogService.deployment.container.env.SERVER_PORT }}
+              value: {{ quote .Values.unguard.microblogService.deployment.container.env.SERVER_PORT }}
             - name: REDIS_SERVICE_ADDRESS
-              value: {{ quote .Values.microblogService.deployment.container.env.REDIS_SERVICE_ADDRESS }}
+              value: {{ quote .Values.unguard.microblogService.deployment.container.env.REDIS_SERVICE_ADDRESS }}
             - name: USER_AUTH_SERVICE_ADDRESS
-              value: {{ quote .Values.microblogService.deployment.container.env.USER_AUTH_SERVICE_ADDRESS }}
+              value: {{ quote .Values.unguard.microblogService.deployment.container.env.USER_AUTH_SERVICE_ADDRESS }}
             - name: OPENTRACING_JAEGER_ENABLED
-              value: {{ quote .Values.microblogService.deployment.container.env.OPENTRACING_JAEGER_ENABLED }}
+              value: {{ quote .Values.unguard.microblogService.deployment.container.env.OPENTRACING_JAEGER_ENABLED }}
             - name: JAEGER_SERVICE_NAME
-              value: {{ quote (printf "unguard-%s" .Values.microblogService.name) }}
+              value: {{ quote (printf "unguard-%s" .Values.unguard.microblogService.name) }}
             - name: JAEGER_AGENT_HOST
-              value: {{ quote (printf "%s-%s" .Values.jaeger.name .Values.microblogService.deployment.container.env.JAEGER_AGENT_HOST) }}
+              value: {{ quote (printf "%s-%s" .Values.jaeger.name .Values.unguard.microblogService.deployment.container.env.JAEGER_AGENT_HOST) }}
             - name: JAEGER_SAMPLER_TYPE
-              value: {{ quote .Values.microblogService.deployment.container.env.JAEGER_SAMPLER_TYPE }}
+              value: {{ quote .Values.unguard.microblogService.deployment.container.env.JAEGER_SAMPLER_TYPE }}
             - name: JAEGER_SAMPLER_PARAM
-              value: {{ quote .Values.microblogService.deployment.container.env.JAEGER_SAMPLER_PARAM }}
+              value: {{ quote .Values.unguard.microblogService.deployment.container.env.JAEGER_SAMPLER_PARAM }}
+{{ end }}

--- a/chart/templates/payment-service.yaml
+++ b/chart/templates/payment-service.yaml
@@ -14,75 +14,76 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */}}
 
+{{- if eq .Values.unguard.enabled true }}
 apiVersion: v1
 kind: Service
 metadata:
-  name: unguard-{{ .Values.paymentService.name }}
+  name: unguard-{{ .Values.unguard.paymentService.name }}
   labels:
-    app.kubernetes.io/name: {{ .Values.paymentService.name }}
+    app.kubernetes.io/name: {{ .Values.unguard.paymentService.name }}
     app.kubernetes.io/part-of: unguard
 {{ include "renderLabels" .Values.labels.common | indent 4 }}
 spec:
-  type: {{ .Values.paymentService.service.type }}
+  type: {{ .Values.unguard.paymentService.service.type }}
   selector:
-    app.kubernetes.io/name: {{ .Values.paymentService.name }}
+    app.kubernetes.io/name: {{ .Values.unguard.paymentService.name }}
     app.kubernetes.io/part-of: unguard
   ports:
-    - targetPort: {{ .Values.paymentService.containerPort }}
-      port: {{ .Values.paymentService.service.ports.port }}
+    - targetPort: {{ .Values.unguard.paymentService.containerPort }}
+      port: {{ .Values.unguard.paymentService.service.ports.port }}
 
 ---
 apiVersion: apps/v1
 kind: Deployment
 metadata:
-  name: unguard-{{ .Values.paymentService.name }}
+  name: unguard-{{ .Values.unguard.paymentService.name }}
   labels:
-    app.kubernetes.io/name: {{ .Values.paymentService.name }}
+    app.kubernetes.io/name: {{ .Values.unguard.paymentService.name }}
     app.kubernetes.io/part-of: unguard
 {{ include "renderLabels" .Values.labels.common | indent 4 }}
 spec:
   selector:
     matchLabels:
-      app.kubernetes.io/name: {{ .Values.paymentService.name }}
+      app.kubernetes.io/name: {{ .Values.unguard.paymentService.name }}
       app.kubernetes.io/part-of: unguard
   strategy:
-    type: {{ .Values.paymentService.deployment.strategy.type }}
+    type: {{ .Values.unguard.paymentService.deployment.strategy.type }}
   template:
     metadata:
       labels:
-        app.kubernetes.io/name: {{ .Values.paymentService.name }}
+        app.kubernetes.io/name: {{ .Values.unguard.paymentService.name }}
         app.kubernetes.io/part-of: unguard
 {{ include "renderLabels" .Values.labels.common | indent 8 }}
     spec:
       containers:
-        - name: {{ .Values.paymentService.name }}
-          image: {{ .Values.paymentService.deployment.container.image.repository }}:{{ .Values.envoyProxy.deployment.container.image.tag }}
-          imagePullPolicy: {{ .Values.paymentService.deployment.container.image.pullPolicy }}
+        - name: {{ .Values.unguard.paymentService.name }}
+          image: {{ .Values.unguard.paymentService.deployment.container.image.repository }}:{{ .Values.unguard.envoyProxy.deployment.container.image.tag }}
+          imagePullPolicy: {{ .Values.unguard.paymentService.deployment.container.image.pullPolicy }}
           ports:
-            - containerPort: {{ .Values.paymentService.containerPort }}
+            - containerPort: {{ .Values.unguard.paymentService.containerPort }}
           env:
             - name: SERVER_PORT
-              value: {{ quote .Values.paymentService.containerPort  }}
+              value: {{ quote .Values.unguard.paymentService.containerPort  }}
             - name: API_PATH
-              value: {{ quote .Values.paymentService.deployment.container.env.API_PATH }}
+              value: {{ quote .Values.unguard.paymentService.deployment.container.env.API_PATH }}
             - name: OTEL_LOGS_EXPORTER
-              value: {{ quote .Values.paymentService.deployment.container.env.OTEL_LOGS_EXPORTER }}
+              value: {{ quote .Values.unguard.paymentService.deployment.container.env.OTEL_LOGS_EXPORTER }}
             - name: OTEL_METRICS_EXPORTER
-              value: {{ quote .Values.paymentService.deployment.container.env.OTEL_METRICS_EXPORTER }}
+              value: {{ quote .Values.unguard.paymentService.deployment.container.env.OTEL_METRICS_EXPORTER }}
             - name: OTEL_RESOURCE_ATTRIBUTES
-              value: {{ quote .Values.paymentService.deployment.container.env.OTEL_RESOURCE_ATTRIBUTES }}
+              value: {{ quote .Values.unguard.paymentService.deployment.container.env.OTEL_RESOURCE_ATTRIBUTES }}
             - name: OTEL_TRACES_EXPORTER
-              value: {{ quote .Values.paymentService.deployment.container.env.OTEL_TRACES_EXPORTER }}
+              value: {{ quote .Values.unguard.paymentService.deployment.container.env.OTEL_TRACES_EXPORTER }}
             - name: OTEL_EXPERIMENTAL_SDK_ENABLED
-              value: {{ quote .Values.paymentService.deployment.container.env.OTEL_EXPERIMENTAL_SDK_ENABLED }}
+              value: {{ quote .Values.unguard.paymentService.deployment.container.env.OTEL_EXPERIMENTAL_SDK_ENABLED }}
             - name: OTEL_EXPORTER_OTLP_ENDPOINT
-              value: {{ quote .Values.paymentService.deployment.container.env.OTEL_EXPORTER_OTLP_ENDPOINT }}
+              value: {{ quote .Values.unguard.paymentService.deployment.container.env.OTEL_EXPORTER_OTLP_ENDPOINT }}
             - name: OTEL_EXPORTER_OTLP_PROTOCOL
-              value: {{ quote .Values.paymentService.deployment.container.env.OTEL_EXPORTER_OTLP_PROTOCOL }}
+              value: {{ quote .Values.unguard.paymentService.deployment.container.env.OTEL_EXPORTER_OTLP_PROTOCOL }}
             - name: OTEL_PROPAGATORS
-              value: {{ quote .Values.paymentService.deployment.container.env.OTEL_PROPAGATORS }}
+              value: {{ quote .Values.unguard.paymentService.deployment.container.env.OTEL_PROPAGATORS }}
             - name: OTEL_PYTHON_LOGGING_AUTO_INSTRUMENTATION_ENABLED
-              value: {{ quote .Values.paymentService.deployment.container.env.OTEL_PYTHON_LOGGING_AUTO_INSTRUMENTATION_ENABLED }}
+              value: {{ quote .Values.unguard.paymentService.deployment.container.env.OTEL_PYTHON_LOGGING_AUTO_INSTRUMENTATION_ENABLED }}
             - name: PROTOCOL_BUFFERS_PYTHON_IMPLEMENTATION
               value: "python"
-
+{{ end }}

--- a/chart/templates/profile-service.yaml
+++ b/chart/templates/profile-service.yaml
@@ -13,76 +13,79 @@ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 See the License for the specific language governing permissions and
 limitations under the License.
 */}}
+
+{{- if eq .Values.unguard.enabled true }}
 apiVersion: v1
 kind: Service
 metadata:
-  name: unguard-{{ .Values.profileService.name }}
+  name: unguard-{{ .Values.unguard.profileService.name }}
   labels:
-    app.kubernetes.io/name: {{ .Values.profileService.name }}
+    app.kubernetes.io/name: {{ .Values.unguard.profileService.name }}
     app.kubernetes.io/part-of: unguard
 {{ include "renderLabels" .Values.labels.common | indent 4 }}
 spec:
-  type: {{ .Values.profileService.service.type }}
+  type: {{ .Values.unguard.profileService.service.type }}
   selector:
-    app.kubernetes.io/name: {{ .Values.profileService.name }}
+    app.kubernetes.io/name: {{ .Values.unguard.profileService.name }}
     app.kubernetes.io/part-of: unguard
   ports:
- {{- .Values.profileService.service.ports | toYaml | nindent 4 }}
+ {{- .Values.unguard.profileService.service.ports | toYaml | nindent 4 }}
 ---
 apiVersion: apps/v1
 kind: Deployment
 metadata:
-  name: unguard-{{ .Values.profileService.name }}
+  name: unguard-{{ .Values.unguard.profileService.name }}
   labels:
-    app.kubernetes.io/name: {{ .Values.profileService.name }}
+    app.kubernetes.io/name: {{ .Values.unguard.profileService.name }}
     app.kubernetes.io/part-of: unguard
 {{ include "renderLabels" .Values.labels.common | indent 4 }}
 spec:
   selector:
     matchLabels:
-      app.kubernetes.io/name: {{ .Values.profileService.name }}
+      app.kubernetes.io/name: {{ .Values.unguard.profileService.name }}
       app.kubernetes.io/part-of: unguard
   strategy:
-    type: {{ .Values.profileService.deployment.strategy.type }}
+    type: {{ .Values.unguard.profileService.deployment.strategy.type }}
   template:
     metadata:
       labels:
-        app.kubernetes.io/name: {{ .Values.profileService.name }}
+        app.kubernetes.io/name: {{ .Values.unguard.profileService.name }}
         app.kubernetes.io/part-of: unguard
 {{ include "renderLabels" .Values.labels.common | indent 8 }}
     spec:
       containers:
-        - name: {{ .Values.profileService.name }}
-          image: {{ .Values.profileService.deployment.container.image.repository }}:{{ .Values.profileService.deployment.container.image.tag | default .Chart.AppVersion }}
-          imagePullPolicy: {{ .Values.profileService.deployment.container.image.pullPolicy }}
+        - name: {{ .Values.unguard.profileService.name }}
+          image: {{ .Values.unguard.profileService.deployment.container.image.repository }}:{{ .Values.unguard.profileService.deployment.container.image.tag | default .Chart.AppVersion }}
+          imagePullPolicy: {{ .Values.unguard.profileService.deployment.container.image.pullPolicy }}
           ports:
-            - containerPort: {{ .Values.profileService.deployment.container.ports.containerPort }}
+            - containerPort: {{ .Values.unguard.profileService.deployment.container.ports.containerPort }}
           livenessProbe:
             httpGet:
-              path: {{ .Values.profileService.deployment.container.livenessProbe.httpGet.path }}
-              port: {{ .Values.profileService.deployment.container.livenessProbe.httpGet.port }}
-            initialDelaySeconds: {{ .Values.profileService.deployment.container.livenessProbe.initialDelaySeconds }}
-            periodSeconds: {{ .Values.profileService.deployment.container.livenessProbe.periodSeconds }}
+              path: {{ .Values.unguard.profileService.deployment.container.livenessProbe.httpGet.path }}
+              port: {{ .Values.unguard.profileService.deployment.container.livenessProbe.httpGet.port }}
+            initialDelaySeconds: {{ .Values.unguard.profileService.deployment.container.livenessProbe.initialDelaySeconds }}
+            periodSeconds: {{ .Values.unguard.profileService.deployment.container.livenessProbe.periodSeconds }}
           env:
             - name: SPRING_DATASOURCE_URL
-              value: {{ quote .Values.profileService.deployment.container.env.SPRING_DATASOURCE_URL }}
+              value: {{ quote .Values.unguard.profileService.deployment.container.env.SPRING_DATASOURCE_URL }}
             - name: SPRING_DATASOURCE_USERNAME
-              value: {{ quote .Values.profileService.deployment.container.env.SPRING_DATASOURCE_USERNAME }}
+              value: {{ quote .Values.unguard.profileService.deployment.container.env.SPRING_DATASOURCE_USERNAME }}
             - name: SPRING_DATASOURCE_PASSWORD
-              value: {{ quote .Values.profileService.deployment.container.env.SPRING_DATASOURCE_PASSWORD }}
+              value: {{ quote .Values.unguard.profileService.deployment.container.env.SPRING_DATASOURCE_PASSWORD }}
             - name: OTEL_LOGS_EXPORTER
-              value: {{ quote .Values.profileService.deployment.container.env.OTEL_LOGS_EXPORTER }}
+              value: {{ quote .Values.unguard.profileService.deployment.container.env.OTEL_LOGS_EXPORTER }}
             - name: OTEL_METRICS_EXPORTER
-              value: {{ quote .Values.profileService.deployment.container.env.OTEL_METRICS_EXPORTER }}
+              value: {{ quote .Values.unguard.profileService.deployment.container.env.OTEL_METRICS_EXPORTER }}
             - name: OTEL_RESOURCE_ATTRIBUTES
-              value: {{ quote .Values.profileService.deployment.container.env.OTEL_RESOURCE_ATTRIBUTES }}
+              value: {{ quote .Values.unguard.profileService.deployment.container.env.OTEL_RESOURCE_ATTRIBUTES }}
             - name: OTEL_TRACES_EXPORTER
-              value: {{ quote .Values.profileService.deployment.container.env.OTEL_TRACES_EXPORTER }}
+              value: {{ quote .Values.unguard.profileService.deployment.container.env.OTEL_TRACES_EXPORTER }}
             {{ if .Values.tracing.enabled }}
             - name: OTEL_EXPERIMENTAL_SDK_ENABLED
-              value: {{ quote .Values.profileService.deployment.container.env.OTEL_EXPERIMENTAL_SDK_ENABLED }}
+              value: {{ quote .Values.unguard.profileService.deployment.container.env.OTEL_EXPERIMENTAL_SDK_ENABLED }}
             - name: OTEL_EXPORTER_JAEGER_ENDPOINT
-              value: {{ quote .Values.profileService.deployment.container.env.OTEL_EXPORTER_JAEGER_ENDPOINT }}
+              value: {{ quote .Values.unguard.profileService.deployment.container.env.OTEL_EXPORTER_JAEGER_ENDPOINT }}
             - name: OTEL_PROPAGATORS
-              value: {{ quote .Values.profileService.deployment.container.env.OTEL_PROPAGATORS }}
+              value: {{ quote .Values.unguard.profileService.deployment.container.env.OTEL_PROPAGATORS }}
             {{ end }}
+{{ end }}

--- a/chart/templates/proxy-service.yaml
+++ b/chart/templates/proxy-service.yaml
@@ -14,97 +14,99 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */}}
 
+{{- if eq .Values.unguard.enabled true }}
 apiVersion: v1
 kind: Service
 metadata:
-  name: unguard-{{ .Values.proxyService.name }}
+  name: unguard-{{ .Values.unguard.proxyService.name }}
   labels:
-    app.kubernetes.io/name: {{ .Values.proxyService.name }}
+    app.kubernetes.io/name: {{ .Values.unguard.proxyService.name }}
     app.kubernetes.io/part-of: unguard
 {{ include "renderLabels" .Values.labels.common | indent 4 }}
 spec:
-  type: {{ .Values.proxyService.service.type }}
+  type: {{ .Values.unguard.proxyService.service.type }}
   selector:
-    app.kubernetes.io/name: {{ .Values.proxyService.name }}
+    app.kubernetes.io/name: {{ .Values.unguard.proxyService.name }}
     app.kubernetes.io/part-of: unguard
   ports:
- {{- .Values.proxyService.service.ports | toYaml | nindent 4 }}
+ {{- .Values.unguard.proxyService.service.ports | toYaml | nindent 4 }}
 ---
 apiVersion: v1
 kind: ServiceAccount
 metadata:
-  name: {{ .Values.proxyService.serviceAccount.name }}
+  name: {{ .Values.unguard.proxyService.serviceAccount.name }}
   labels:
-    app.kubernetes.io/name: {{ .Values.proxyService.name }}
+    app.kubernetes.io/name: {{ .Values.unguard.proxyService.name }}
     app.kubernetes.io/part-of: unguard
 {{ include "renderLabels" .Values.labels.common | indent 4 }}
 ---
 apiVersion: rbac.authorization.k8s.io/v1
 kind: Role
 metadata:
-  name: {{ .Values.proxyService.role.name }}
+  name: {{ .Values.unguard.proxyService.role.name }}
   labels:
-    app.kubernetes.io/name: {{ .Values.proxyService.name }}
+    app.kubernetes.io/name: {{ .Values.unguard.proxyService.name }}
     app.kubernetes.io/part-of: unguard
 {{ include "renderLabels" .Values.labels.common | indent 4 }}
 rules:
-  {{- .Values.proxyService.role.rules | toYaml | nindent 2 }}
+  {{- .Values.unguard.proxyService.role.rules | toYaml | nindent 2 }}
 
 ---
 kind: RoleBinding
 apiVersion: rbac.authorization.k8s.io/v1
 metadata:
-  name: {{ .Values.proxyService.roleBindings.name }}
+  name: {{ .Values.unguard.proxyService.roleBindings.name }}
   labels:
-    app.kubernetes.io/name: {{ .Values.proxyService.name }}
+    app.kubernetes.io/name: {{ .Values.unguard.proxyService.name }}
     app.kubernetes.io/part-of: unguard
 {{ include "renderLabels" .Values.labels.common | indent 4 }}
 subjects:
-  {{- .Values.proxyService.roleBindings.subjects | toYaml | nindent 2 }}
+  {{- .Values.unguard.proxyService.roleBindings.subjects | toYaml | nindent 2 }}
 roleRef:
-  kind: {{ .Values.proxyService.roleBindings.roleRef.kind }}
-  name: {{ .Values.proxyService.roleBindings.roleRef.name }}
-  apiGroup: {{ .Values.proxyService.roleBindings.roleRef.apiGroup }}
+  kind: {{ .Values.unguard.proxyService.roleBindings.roleRef.kind }}
+  name: {{ .Values.unguard.proxyService.roleBindings.roleRef.name }}
+  apiGroup: {{ .Values.unguard.proxyService.roleBindings.roleRef.apiGroup }}
 ---
 apiVersion: apps/v1
 kind: Deployment
 metadata:
-  name: unguard-{{ .Values.proxyService.name }}
+  name: unguard-{{ .Values.unguard.proxyService.name }}
   labels:
-    app.kubernetes.io/name: {{ .Values.proxyService.name }}
+    app.kubernetes.io/name: {{ .Values.unguard.proxyService.name }}
     app.kubernetes.io/part-of: unguard
 {{ include "renderLabels" .Values.labels.common | indent 4 }}
 spec:
   selector:
     matchLabels:
-      app.kubernetes.io/name: {{ .Values.proxyService.name }}
+      app.kubernetes.io/name: {{ .Values.unguard.proxyService.name }}
       app.kubernetes.io/part-of: unguard
   strategy:
-    type: {{ .Values.proxyService.deployment.strategy.type }}
+    type: {{ .Values.unguard.proxyService.deployment.strategy.type }}
   template:
     metadata:
       labels:
-        app.kubernetes.io/name: {{ .Values.proxyService.name }}
+        app.kubernetes.io/name: {{ .Values.unguard.proxyService.name }}
         app.kubernetes.io/part-of: unguard
 {{ include "renderLabels" .Values.labels.common | indent 8 }}
     spec:
-      serviceAccountName: {{ .Values.proxyService.serviceAccount.name }}
+      serviceAccountName: {{ .Values.unguard.proxyService.serviceAccount.name }}
       containers:
-        - name: {{ .Values.proxyService.name }}
-          image: {{ .Values.proxyService.deployment.container.image.repository }}:{{ .Values.proxyService.deployment.container.image.tag }}
-          imagePullPolicy: {{ .Values.statusService.deployment.container.image.pullPolicy }}
+        - name: {{ .Values.unguard.proxyService.name }}
+          image: {{ .Values.unguard.proxyService.deployment.container.image.repository }}:{{ .Values.unguard.proxyService.deployment.container.image.tag }}
+          imagePullPolicy: {{ .Values.unguard.statusService.deployment.container.image.pullPolicy }}
           ports:
-            - containerPort: {{ .Values.proxyService.deployment.container.ports.containerPort }}
+            - containerPort: {{ .Values.unguard.proxyService.deployment.container.ports.containerPort }}
           env:
             - name: SERVER_PORT
-              value: {{ quote .Values.proxyService.deployment.container.env.SERVER_PORT }}
+              value: {{ quote .Values.unguard.proxyService.deployment.container.env.SERVER_PORT }}
             - name: OPENTRACING_JAEGER_ENABLED
-              value: {{ quote .Values.proxyService.deployment.container.env.OPENTRACING_JAEGER_ENABLED }}
+              value: {{ quote .Values.unguard.proxyService.deployment.container.env.OPENTRACING_JAEGER_ENABLED }}
             - name: JAEGER_SERVICE_NAME
-              value: {{ quote (printf "unguard-%s" .Values.proxyService.name) }}
+              value: {{ quote (printf "unguard-%s" .Values.unguard.proxyService.name) }}
             - name: JAEGER_AGENT_HOST
-              value: {{ quote (printf "%s-%s" .Values.jaeger.name .Values.proxyService.deployment.container.env.JAEGER_AGENT_HOST) }}
+              value: {{ quote (printf "%s-%s" .Values.jaeger.name .Values.unguard.proxyService.deployment.container.env.JAEGER_AGENT_HOST) }}
             - name: JAEGER_SAMPLER_TYPE
-              value: {{ quote .Values.proxyService.deployment.container.env.JAEGER_SAMPLER_TYPE }}
+              value: {{ quote .Values.unguard.proxyService.deployment.container.env.JAEGER_SAMPLER_TYPE }}
             - name: JAEGER_SAMPLER_PARAM
-              value: {{ quote .Values.proxyService.deployment.container.env.JAEGER_SAMPLER_PARAM }}
+              value: {{ quote .Values.unguard.proxyService.deployment.container.env.JAEGER_SAMPLER_PARAM }}
+{{ end }}

--- a/chart/templates/redis.yaml
+++ b/chart/templates/redis.yaml
@@ -14,6 +14,7 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */}}
 
+{{- if eq .Values.unguard.enabled true }}
 apiVersion: v1
 kind: Service
 metadata:
@@ -103,3 +104,4 @@ spec:
             items:
               - key: redis-config
                 path: redis.conf
+{{ end }}

--- a/chart/templates/status-service.yaml
+++ b/chart/templates/status-service.yaml
@@ -14,29 +14,30 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */}}
 
+{{- if eq .Values.unguard.enabled true }}
 apiVersion: v1
 kind: Service
 metadata:
-  name: unguard-{{ .Values.statusService.name }}
+  name: unguard-{{ .Values.unguard.statusService.name }}
   labels:
-    app.kubernetes.io/name: {{ .Values.statusService.name }}
+    app.kubernetes.io/name: {{ .Values.unguard.statusService.name }}
     app.kubernetes.io/part-of: unguard
 {{ include "renderLabels" .Values.labels.common | indent 4 }}
 spec:
-  type: {{ .Values.statusService.service.type }}
+  type: {{ .Values.unguard.statusService.service.type }}
   selector:
-    app.kubernetes.io/name: {{ .Values.statusService.name }}
+    app.kubernetes.io/name: {{ .Values.unguard.statusService.name }}
     app.kubernetes.io/part-of: unguard
   ports:
- {{- .Values.statusService.service.ports | toYaml | nindent 4 }}
+ {{- .Values.unguard.statusService.service.ports | toYaml | nindent 4 }}
 
 ---
 apiVersion: v1
 kind: ServiceAccount
 metadata:
-  name: {{ .Values.statusService.serviceAccount.name }}
+  name: {{ .Values.unguard.statusService.serviceAccount.name }}
   labels:
-    app.kubernetes.io/name: {{ .Values.statusService.name }}
+    app.kubernetes.io/name: {{ .Values.unguard.statusService.name }}
     app.kubernetes.io/part-of: unguard
 {{ include "renderLabels" .Values.labels.common | indent 4 }}
 
@@ -44,73 +45,74 @@ metadata:
 apiVersion: rbac.authorization.k8s.io/v1
 kind: Role
 metadata:
-  name: {{ .Values.statusService.role.name }}
+  name: {{ .Values.unguard.statusService.role.name }}
   labels:
-    app.kubernetes.io/name: {{ .Values.statusService.name }}
+    app.kubernetes.io/name: {{ .Values.unguard.statusService.name }}
     app.kubernetes.io/part-of: unguard
 {{ include "renderLabels" .Values.labels.common | indent 4 }}
 rules:
-  {{- .Values.statusService.role.rules | toYaml | nindent 2 }}
+  {{- .Values.unguard.statusService.role.rules | toYaml | nindent 2 }}
 
 ---
 kind: RoleBinding
 apiVersion: rbac.authorization.k8s.io/v1
 metadata:
-  name: {{ .Values.statusService.roleBindings.name }}
+  name: {{ .Values.unguard.statusService.roleBindings.name }}
   labels:
-    app.kubernetes.io/name: {{ .Values.statusService.name }}
+    app.kubernetes.io/name: {{ .Values.unguard.statusService.name }}
     app.kubernetes.io/part-of: unguard
 {{ include "renderLabels" .Values.labels.common | indent 4 }}
 subjects:
-  {{- .Values.statusService.roleBindings.subjects | toYaml | nindent 2 }}
+  {{- .Values.unguard.statusService.roleBindings.subjects | toYaml | nindent 2 }}
 roleRef:
-  kind: {{ .Values.statusService.roleBindings.roleRef.kind }}
-  name: {{ .Values.statusService.roleBindings.roleRef.name }}
-  apiGroup: {{ .Values.statusService.roleBindings.roleRef.apiGroup }}
+  kind: {{ .Values.unguard.statusService.roleBindings.roleRef.kind }}
+  name: {{ .Values.unguard.statusService.roleBindings.roleRef.name }}
+  apiGroup: {{ .Values.unguard.statusService.roleBindings.roleRef.apiGroup }}
 
 ---
 apiVersion: apps/v1
 kind: Deployment
 metadata:
-  name: unguard-{{ .Values.statusService.name }}
+  name: unguard-{{ .Values.unguard.statusService.name }}
   labels:
-    app.kubernetes.io/name: {{ .Values.statusService.name }}
+    app.kubernetes.io/name: {{ .Values.unguard.statusService.name }}
     app.kubernetes.io/part-of: unguard
 {{ include "renderLabels" .Values.labels.common | indent 4 }}
 spec:
   selector:
     matchLabels:
-      app.kubernetes.io/name: {{ .Values.statusService.name }}
+      app.kubernetes.io/name: {{ .Values.unguard.statusService.name }}
       app.kubernetes.io/part-of: unguard
   strategy:
-    type: {{ .Values.statusService.deployment.strategy.type }}
+    type: {{ .Values.unguard.statusService.deployment.strategy.type }}
   template:
     metadata:
       labels:
-        app.kubernetes.io/name: {{ .Values.statusService.name }}
+        app.kubernetes.io/name: {{ .Values.unguard.statusService.name }}
         app.kubernetes.io/part-of: unguard
 {{ include "renderLabels" .Values.labels.common | indent 8 }}
     spec:
-      serviceAccountName: {{ .Values.statusService.serviceAccount.name }}
+      serviceAccountName: {{ .Values.unguard.statusService.serviceAccount.name }}
       containers:
-        - name: {{ .Values.statusService.name }}
-          image: {{ .Values.statusService.deployment.container.image.repository }}:{{ .Values.statusService.deployment.container.image.tag }}
-          imagePullPolicy: {{ .Values.statusService.deployment.container.image.pullPolicy }}
+        - name: {{ .Values.unguard.statusService.name }}
+          image: {{ .Values.unguard.statusService.deployment.container.image.repository }}:{{ .Values.unguard.statusService.deployment.container.image.tag }}
+          imagePullPolicy: {{ .Values.unguard.statusService.deployment.container.image.pullPolicy }}
           ports:
-            - containerPort: {{ .Values.statusService.deployment.container.ports.containerPort }}
+            - containerPort: {{ .Values.unguard.statusService.deployment.container.ports.containerPort }}
           env:
             - name: SERVER_PORT
-              value: {{ quote .Values.statusService.deployment.container.env.SERVER_PORT }}
+              value: {{ quote .Values.unguard.statusService.deployment.container.env.SERVER_PORT }}
             - name: API_PATH
-              value: {{ quote .Values.statusService.deployment.container.env.API_PATH }}
+              value: {{ quote .Values.unguard.statusService.deployment.container.env.API_PATH }}
             - name: KUBERNETES_NAMESPACE
-              value: {{ quote .Values.statusService.deployment.container.env.KUBERNETES_NAMESPACE }}
+              value: {{ quote .Values.unguard.statusService.deployment.container.env.KUBERNETES_NAMESPACE }}
             - name: IGNORED_DEPLOYMENTS # add deployments to ignore separated by spaces
-              value: {{ quote .Values.statusService.deployment.container.env.IGNORED_DEPLOYMENTS }}
+              value: {{ quote .Values.unguard.statusService.deployment.container.env.IGNORED_DEPLOYMENTS }}
             - name: MARIADB_SERVICE
-              value: {{ tpl .Values.statusService.deployment.container.env.MARIADB_SERVICE . | quote }}
+              value: {{ tpl .Values.unguard.statusService.deployment.container.env.MARIADB_SERVICE . | quote }}
             - name: MARIADB_PASSWORD
               valueFrom:
                 secretKeyRef:
-                  name: {{ tpl .Values.statusService.deployment.container.env.MARIADB_PASSWORD.secretKeyRef.name . }}
-                  key: {{ tpl .Values.statusService.deployment.container.env.MARIADB_PASSWORD.secretKeyRef.key . }}
+                  name: {{ tpl .Values.unguard.statusService.deployment.container.env.MARIADB_PASSWORD.secretKeyRef.name . }}
+                  key: {{ tpl .Values.unguard.statusService.deployment.container.env.MARIADB_PASSWORD.secretKeyRef.key . }}
+{{ end }}

--- a/chart/templates/tests/test-frontend-connection.yaml
+++ b/chart/templates/tests/test-frontend-connection.yaml
@@ -1,3 +1,4 @@
+{{- if eq .Values.unguard.enabled true }}
 apiVersion: v1
 kind: Pod
 metadata:
@@ -9,14 +10,15 @@ metadata:
     "helm.sh/hook": test
 spec:
   containers:
-    - name: unguard-{{ .Values.userSimulator.name }}
-      image: {{ .Values.userSimulator.cronJob.jobTemplate.container.image.repository }}:{{ .Values.userSimulator.cronJob.jobTemplate.container.image.tag }}
-      imagePullPolicy: {{ .Values.userSimulator.cronJob.jobTemplate.container.image.pullPolicy }}
+    - name: unguard-{{ .Values.unguard.userSimulator.name }}
+      image: {{ .Values.unguard.userSimulator.cronJob.jobTemplate.container.image.repository }}:{{ .Values.unguard.userSimulator.cronJob.jobTemplate.container.image.tag }}
+      imagePullPolicy: {{ .Values.unguard.userSimulator.cronJob.jobTemplate.container.image.pullPolicy }}
       env:
         - name: FRONTEND_ADDR
-          value: {{ quote .Values.userSimulator.cronJob.jobTemplate.container.env.FRONTEND_ADDR }}
+          value: {{ quote .Values.unguard.userSimulator.cronJob.jobTemplate.container.env.FRONTEND_ADDR }}
         - name: SIMULATE_PRIVATE_RANGES
-          value: {{ quote .Values.userSimulator.cronJob.jobTemplate.container.env.SIMULATE_PRIVATE_RANGES }}
+          value: {{ quote .Values.unguard.userSimulator.cronJob.jobTemplate.container.env.SIMULATE_PRIVATE_RANGES }}
       command: ["/bin/sh"]
       args: ["-c", "node_modules/.bin/element run default-user-sim.perf.ts --export 2>&1 && jq -e '.testScripts[].iterationResults[].stepResults[] | select(.status == \"failed\") | .name' reports/default-user-sim.perf/*/data.json >/dev/null && exit 1 || exit 0"]
   restartPolicy: Never
+{{- end }}

--- a/chart/templates/user-auth-service.yaml
+++ b/chart/templates/user-auth-service.yaml
@@ -14,68 +14,70 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */}}
 
+{{- if eq .Values.unguard.enabled true }}
 apiVersion: v1
 kind: Service
 metadata:
-  name: unguard-{{ .Values.userAuthService.name }}
+  name: unguard-{{ .Values.unguard.userAuthService.name }}
   labels:
-    app.kubernetes.io/name: {{ .Values.userAuthService.name }}
+    app.kubernetes.io/name: {{ .Values.unguard.userAuthService.name }}
     app.kubernetes.io/part-of: unguard
 {{ include "renderLabels" .Values.labels.common | indent 4 }}
 spec:
-  type: {{ .Values.userAuthService.service.type }}
+  type: {{ .Values.unguard.userAuthService.service.type }}
   selector:
-    app.kubernetes.io/name: {{ .Values.userAuthService.name }}
+    app.kubernetes.io/name: {{ .Values.unguard.userAuthService.name }}
     app.kubernetes.io/part-of: unguard
   ports:
- {{- .Values.userAuthService.service.ports | toYaml | nindent 4 }}
+ {{- .Values.unguard.userAuthService.service.ports | toYaml | nindent 4 }}
 
 ---
 apiVersion: apps/v1
 kind: Deployment
 metadata:
-  name: unguard-{{ .Values.userAuthService.name }}
+  name: unguard-{{ .Values.unguard.userAuthService.name }}
   labels:
-    app.kubernetes.io/name: {{ .Values.userAuthService.name }}
+    app.kubernetes.io/name: {{ .Values.unguard.userAuthService.name }}
     app.kubernetes.io/part-of: unguard
 {{ include "renderLabels" .Values.labels.common | indent 4 }}
 spec:
   selector:
     matchLabels:
-      app.kubernetes.io/name: {{ .Values.userAuthService.name }}
+      app.kubernetes.io/name: {{ .Values.unguard.userAuthService.name }}
       app.kubernetes.io/part-of: unguard
   strategy:
-    type: {{ .Values.userAuthService.deployment.strategy.type }}
+    type: {{ .Values.unguard.userAuthService.deployment.strategy.type }}
   template:
     metadata:
       labels:
-        app.kubernetes.io/name: {{ .Values.userAuthService.name }}
+        app.kubernetes.io/name: {{ .Values.unguard.userAuthService.name }}
         app.kubernetes.io/part-of: unguard
 {{ include "renderLabels" .Values.labels.common | indent 8 }}
     spec:
       containers:
-        - name: {{ .Values.userAuthService.name }}
-          image: {{ .Values.userAuthService.deployment.container.image.repository }}:{{ .Values.userAuthService.deployment.container.image.tag }}
-          imagePullPolicy: {{ .Values.userAuthService.deployment.container.image.pullPolicy }}
+        - name: {{ .Values.unguard.userAuthService.name }}
+          image: {{ .Values.unguard.userAuthService.deployment.container.image.repository }}:{{ .Values.unguard.userAuthService.deployment.container.image.tag }}
+          imagePullPolicy: {{ .Values.unguard.userAuthService.deployment.container.image.pullPolicy }}
           ports:
-            - containerPort: {{ .Values.userAuthService.deployment.container.ports.containerPort }}
+            - containerPort: {{ .Values.unguard.userAuthService.deployment.container.ports.containerPort }}
           env:
             - name: SERVER_PORT
-              value: {{ quote .Values.userAuthService.deployment.container.env.SERVER_PORT }}
+              value: {{ quote .Values.unguard.userAuthService.deployment.container.env.SERVER_PORT }}
             - name: MARIADB_SERVICE
-              value: {{ tpl .Values.userAuthService.deployment.container.env.MARIADB_SERVICE . | quote }}
+              value: {{ tpl .Values.unguard.userAuthService.deployment.container.env.MARIADB_SERVICE . | quote }}
             - name: MARIADB_PASSWORD
               valueFrom:
                 secretKeyRef:
-                  name: {{ tpl .Values.userAuthService.deployment.container.env.MARIADB_PASSWORD.secretKeyRef.name . }}
-                  key: {{ tpl .Values.userAuthService.deployment.container.env.MARIADB_PASSWORD.secretKeyRef.key .  }}
+                  name: {{ tpl .Values.unguard.userAuthService.deployment.container.env.MARIADB_PASSWORD.secretKeyRef.name . }}
+                  key: {{ tpl .Values.unguard.userAuthService.deployment.container.env.MARIADB_PASSWORD.secretKeyRef.key .  }}
             - name: JAEGER_SERVICE_NAME
-              value: {{ quote (printf "unguard-%s" .Values.userAuthService.name) }}
+              value: {{ quote (printf "unguard-%s" .Values.unguard.userAuthService.name) }}
             - name: JAEGER_AGENT_HOST
-              value: {{ quote (printf "%s-%s" .Values.jaeger.name .Values.userAuthService.deployment.container.env.JAEGER_AGENT_HOST) }}
+              value: {{ quote (printf "%s-%s" .Values.jaeger.name .Values.unguard.userAuthService.deployment.container.env.JAEGER_AGENT_HOST) }}
             - name: JAEGER_SAMPLER_TYPE
-              value: {{ quote .Values.userAuthService.deployment.container.env.JAEGER_SAMPLER_TYPE }}
+              value: {{ quote .Values.unguard.userAuthService.deployment.container.env.JAEGER_SAMPLER_TYPE }}
             - name: JAEGER_SAMPLER_PARAM
-              value: {{ quote .Values.userAuthService.deployment.container.env.JAEGER_SAMPLER_PARAM }}
+              value: {{ quote .Values.unguard.userAuthService.deployment.container.env.JAEGER_SAMPLER_PARAM }}
             - name: JAEGER_DISABLED
-              value: {{ quote .Values.userAuthService.deployment.container.env.JAEGER_DISABLED }}
+              value: {{ quote .Values.unguard.userAuthService.deployment.container.env.JAEGER_DISABLED }}
+{{ end }}

--- a/chart/templates/user-simulator.yaml
+++ b/chart/templates/user-simulator.yaml
@@ -14,40 +14,42 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */}}
 
+{{- if eq .Values.unguard.enabled true }}
 apiVersion: batch/v1
 kind: CronJob
 metadata:
-  name: unguard-{{ .Values.userSimulator.name }}
+  name: unguard-{{ .Values.unguard.userSimulator.name }}
   labels:
-    app.kubernetes.io/name: {{ .Values.userSimulator.name }}
+    app.kubernetes.io/name: {{ .Values.unguard.userSimulator.name }}
     app.kubernetes.io/part-of: unguard
 {{ include "renderLabels" .Values.labels.common | indent 4 }}
 spec:
-  schedule: {{ quote .Values.userSimulator.cronJob.schedule }}
-  startingDeadlineSeconds: {{ .Values.userSimulator.cronJob.startingDeadlineSeconds }}
+  schedule: {{ quote .Values.unguard.userSimulator.cronJob.schedule }}
+  startingDeadlineSeconds: {{ .Values.unguard.userSimulator.cronJob.startingDeadlineSeconds }}
   jobTemplate:
     spec:
       template:
         metadata:
           labels:
-            app.kubernetes.io/name: {{ .Values.userSimulator.name }}
+            app.kubernetes.io/name: {{ .Values.unguard.userSimulator.name }}
             app.kubernetes.io/part-of: unguard
 {{ include "renderLabels" .Values.labels.common | indent 12 }}
         spec:
-          restartPolicy: {{ .Values.userSimulator.cronJob.jobTemplate.restartPolicy }}
+          restartPolicy: {{ .Values.unguard.userSimulator.cronJob.jobTemplate.restartPolicy }}
           containers:
-            - name: unguard-{{ .Values.userSimulator.name }}
-              image: {{ .Values.userSimulator.cronJob.jobTemplate.container.image.repository }}:{{ .Values.userSimulator.cronJob.jobTemplate.container.image.tag }}
-              imagePullPolicy: {{ .Values.userSimulator.cronJob.jobTemplate.container.image.pullPolicy }}
+            - name: unguard-{{ .Values.unguard.userSimulator.name }}
+              image: {{ .Values.unguard.userSimulator.cronJob.jobTemplate.container.image.repository }}:{{ .Values.unguard.userSimulator.cronJob.jobTemplate.container.image.tag }}
+              imagePullPolicy: {{ .Values.unguard.userSimulator.cronJob.jobTemplate.container.image.pullPolicy }}
               env:
                 - name: FRONTEND_ADDR
-                  value: {{ quote .Values.userSimulator.cronJob.jobTemplate.container.env.FRONTEND_ADDR }}
+                  value: {{ quote .Values.unguard.userSimulator.cronJob.jobTemplate.container.env.FRONTEND_ADDR }}
                 - name: SIMULATE_PRIVATE_RANGES
-                  value: {{ quote .Values.userSimulator.cronJob.jobTemplate.container.env.SIMULATE_PRIVATE_RANGES }}
+                  value: {{ quote .Values.unguard.userSimulator.cronJob.jobTemplate.container.env.SIMULATE_PRIVATE_RANGES }}
               resources:
                 requests:
-                  cpu: {{ quote .Values.userSimulator.cronJob.jobTemplate.container.resources.requests.cpu }}
-                  memory: {{ quote .Values.userSimulator.cronJob.jobTemplate.container.resources.requests.memory }}
+                  cpu: {{ quote .Values.unguard.userSimulator.cronJob.jobTemplate.container.resources.requests.cpu }}
+                  memory: {{ quote .Values.unguard.userSimulator.cronJob.jobTemplate.container.resources.requests.memory }}
                 limits:
-                  cpu: {{ quote .Values.userSimulator.cronJob.jobTemplate.container.resources.limits.cpu }}
-                  memory: {{ quote .Values.userSimulator.cronJob.jobTemplate.container.resources.limits.memory }}
+                  cpu: {{ quote .Values.unguard.userSimulator.cronJob.jobTemplate.container.resources.limits.cpu }}
+                  memory: {{ quote .Values.unguard.userSimulator.cronJob.jobTemplate.container.resources.limits.memory }}
+{{ end }}

--- a/chart/values.yaml
+++ b/chart/values.yaml
@@ -495,6 +495,14 @@ unguard:
           MEMBERSHIP_SERVICE_BASE_PATH: /membership-service
           STATUS_SERVICE_BASE_PATH: /status-service
 
-exploit-toolkit:
+exploit_toolkit:
   enabled: false
-
+  cronjob:
+    schedule: "*/15 * * * * "
+    container:
+      image:
+        repository: ghcr.io/dynatrace-oss/unguard/exploit-toolkit
+        tag: 0.11.2
+        pullPolicy: IfNotPresent
+  script: |
+    /usr/local/bin/ug-exploit login exploit-demo --target totally-secure-unguard.dynatrace.com && /usr/local/bin/ug-exploit cmd-inject-proxy --target totally-secure-unguard.dynatrace.com "whoami"

--- a/chart/values.yaml
+++ b/chart/values.yaml
@@ -41,453 +41,460 @@ labels:
   # Add common labels to all resources here
   common: {}
 
-# Malicious load generator
-maliciousLoadGenerator:
-  enabled: false
-  name: malicious-load-generator
+unguard:
+  enabled: true
 
-  deployment:
-    strategy:
-      type: Recreate
-    terminationGracePeriodSeconds: 5
-    restartPolicy: Always
-    container:
-      image:
-        repository: ghcr.io/dynatrace-oss/unguard/unguard-malicious-load-generator
-        tag: 0.11.2
-        pullPolicy: IfNotPresent
-      ports:
-        containerPort: 8083
-      env:
-        FRONTEND_ADDR: unguard-envoy-proxy:8080/ui
-        USERS: 1
-        WAIT_TIME: 1800
+  # Malicious load generator
+  maliciousLoadGenerator:
+    enabled: false
+    name: malicious-load-generator
 
-# Profile Service
-profileService:
-  name: profile-service
-
-  service:
-    type: ClusterIP
-    ports:
-      - targetPort: 8080
-        port: 80
-  deployment:
-    strategy:
-      type: Recreate
-    container:
-      image:
-        repository: ghcr.io/dynatrace-oss/unguard/unguard-profile-service
-        tag: 0.8.1
-        pullPolicy: IfNotPresent
-      ports:
-        containerPort: 8080
-      env:
-        OTEL_LOGS_EXPORTER: none
-        OTEL_METRICS_EXPORTER: none
-        OTEL_RESOURCE_ATTRIBUTES: service.name=unguard-profile-service
-        OTEL_TRACES_EXPORTER: none
-        OTEL_EXPERIMENTAL_SDK_ENABLED: false
-        OTEL_EXPORTER_JAEGER_ENDPOINT: "http://jaeger-collector:14250"
-        OTEL_PROPAGATORS: "jaeger"
-        SPRING_DATASOURCE_PASSWORD: password
-        SPRING_DATASOURCE_URL: jdbc:h2:file:./database/bio
-        SPRING_DATASOURCE_USERNAME: sa
-      livenessProbe:
-        httpGet:
-          path: /healthz
-          port: 8080
-        initialDelaySeconds: 5
-        periodSeconds: 15
-
-# User Simulator
-userSimulator:
-  name: user-simulator
-
-  cronJob:
-    schedule: "*/3 * * * *"
-    startingDeadlineSeconds: 180
-    jobTemplate:
-      restartPolicy: OnFailure
-
+    deployment:
+      strategy:
+        type: Recreate
+      terminationGracePeriodSeconds: 5
+      restartPolicy: Always
       container:
         image:
-          repository: ghcr.io/dynatrace-oss/unguard/unguard-user-simulator
+          repository: ghcr.io/dynatrace-oss/unguard/unguard-malicious-load-generator
           tag: 0.11.2
           pullPolicy: IfNotPresent
-
+        ports:
+          containerPort: 8083
         env:
           FRONTEND_ADDR: unguard-envoy-proxy:8080/ui
-          SIMULATE_PRIVATE_RANGES: false
+          USERS: 1
+          WAIT_TIME: 1800
 
-        resources:
-          requests:
-            cpu: 10m
-            memory: 256Mi
-          limits:
-            cpu: 500m
-            memory: 512Mi
+  # Profile Service
+  profileService:
+    name: profile-service
 
-# Membership Service
-membershipService:
-  name: membership-service
-
-  service:
-    type: ClusterIP
-    ports:
-      - targetPort: 8083
-        port: 80
-
-  deployment:
-    strategy:
-      type: Recreate
-    container:
-      image:
-        repository: ghcr.io/dynatrace-oss/unguard/unguard-membership-service
-        tag: 0.11.2
-        pullPolicy: IfNotPresent
+    service:
+      type: ClusterIP
       ports:
-        containerPort: 8083
-      env:
-        ASPNETCORE_ENVIRONMENT: Development
-        SERVER_PORT: 8083
-        API_PATH: /membership-service
-        MARIADB_SERVICE: "{{ .Values.mariaDB.serviceName }}"
-        MARIADB_PASSWORD:
-          secretKeyRef:
-            name: "{{ .Values.mariaDB.serviceName }}"
-            key: "{{ .Values.mariaDB.password }}"
+        - targetPort: 8080
+          port: 80
+    deployment:
+      strategy:
+        type: Recreate
+      container:
+        image:
+          repository: ghcr.io/dynatrace-oss/unguard/unguard-profile-service
+          tag: 0.8.1
+          pullPolicy: IfNotPresent
+        ports:
+          containerPort: 8080
+        env:
+          OTEL_LOGS_EXPORTER: none
+          OTEL_METRICS_EXPORTER: none
+          OTEL_RESOURCE_ATTRIBUTES: service.name=unguard-profile-service
+          OTEL_TRACES_EXPORTER: none
+          OTEL_EXPERIMENTAL_SDK_ENABLED: false
+          OTEL_EXPORTER_JAEGER_ENDPOINT: "http://jaeger-collector:14250"
+          OTEL_PROPAGATORS: "jaeger"
+          SPRING_DATASOURCE_PASSWORD: password
+          SPRING_DATASOURCE_URL: jdbc:h2:file:./database/bio
+          SPRING_DATASOURCE_USERNAME: sa
+        livenessProbe:
+          httpGet:
+            path: /healthz
+            port: 8080
+          initialDelaySeconds: 5
+          periodSeconds: 15
 
-# User Auth Service
-userAuthService:
-  name: user-auth-service
+  # User Simulator
+  userSimulator:
+    name: user-simulator
 
-  service:
-    type: ClusterIP
-    ports:
-      - targetPort: 9091
-        port: 80
+    cronJob:
+      schedule: "*/3 * * * *"
+      startingDeadlineSeconds: 180
+      jobTemplate:
+        restartPolicy: OnFailure
 
-  deployment:
-    strategy:
-      type: Recreate
-    container:
-      image:
-        repository: ghcr.io/dynatrace-oss/unguard/unguard-user-auth-service
-        tag: 0.11.2
-        pullPolicy: IfNotPresent
+        container:
+          image:
+            repository: ghcr.io/dynatrace-oss/unguard/unguard-user-simulator
+            tag: 0.11.2
+            pullPolicy: IfNotPresent
+
+          env:
+            FRONTEND_ADDR: unguard-envoy-proxy:8080/ui
+            SIMULATE_PRIVATE_RANGES: false
+
+          resources:
+            requests:
+              cpu: 10m
+              memory: 256Mi
+            limits:
+              cpu: 500m
+              memory: 512Mi
+
+  # Membership Service
+  membershipService:
+    name: membership-service
+
+    service:
+      type: ClusterIP
       ports:
-        containerPort: 9091
-      env:
-        SERVER_PORT: 9091
-        MARIADB_SERVICE: "{{ .Values.mariaDB.serviceName }}"
-        MARIADB_PASSWORD:
-          secretKeyRef:
-            name: "{{ .Values.mariaDB.serviceName }}"
-            key: "{{ .Values.mariaDB.password }}"
-        JAEGER_AGENT_HOST: agent  # change depending on your jaeger deployment
-        JAEGER_SAMPLER_TYPE: const
-        JAEGER_SAMPLER_PARAM: 0
-        JAEGER_DISABLED: true
-        ASPNETCORE_ENVIRONMENT: Production
-        API_PATH: /ad-service
-        USER_AUTH_SERVICE_ADDRESS: unguard-user-auth-service
+        - targetPort: 8083
+          port: 80
 
-# Add Service
-adService:
-  name: ad-service
+    deployment:
+      strategy:
+        type: Recreate
+      container:
+        image:
+          repository: ghcr.io/dynatrace-oss/unguard/unguard-membership-service
+          tag: 0.11.2
+          pullPolicy: IfNotPresent
+        ports:
+          containerPort: 8083
+        env:
+          ASPNETCORE_ENVIRONMENT: Development
+          SERVER_PORT: 8083
+          API_PATH: /membership-service
+          MARIADB_SERVICE: "{{ .Values.mariaDB.serviceName }}"
+          MARIADB_PASSWORD:
+            secretKeyRef:
+              name: "{{ .Values.mariaDB.serviceName }}"
+              key: "{{ .Values.mariaDB.password }}"
 
-  service:
-    type: ClusterIP
-    ports:
-      - targetPort: 8082
-        port: 80
+  # User Auth Service
+  userAuthService:
+    name: user-auth-service
 
-  deployment:
-    strategy:
-      type: Recreate
-    container:
-      image:
-        repository: ghcr.io/dynatrace-oss/unguard/unguard-ad-service
-        tag: 0.11.2
-        pullPolicy: IfNotPresent
+    service:
+      type: ClusterIP
       ports:
-        containerPort: 8082
-      env:
-        JAEGER_AGENT_HOST: agent  # change depending on your jaeger deployment
-        JAEGER_SAMPLER_TYPE: const
-        JAEGER_SAMPLER_PARAM: 0
-        JAEGER_DISABLED: true
-        ASPNETCORE_ENVIRONMENT: Production
-        SERVER_PORT: 8082
-        API_PATH: /ad-service
-        USER_AUTH_SERVICE_ADDRESS: unguard-user-auth-service
+        - targetPort: 9091
+          port: 80
 
-# Envoy Proxy
-envoyProxy:
-  name: envoy-proxy
+    deployment:
+      strategy:
+        type: Recreate
+      container:
+        image:
+          repository: ghcr.io/dynatrace-oss/unguard/unguard-user-auth-service
+          tag: 0.11.2
+          pullPolicy: IfNotPresent
+        ports:
+          containerPort: 9091
+        env:
+          SERVER_PORT: 9091
+          MARIADB_SERVICE: "{{ .Values.mariaDB.serviceName }}"
+          MARIADB_PASSWORD:
+            secretKeyRef:
+              name: "{{ .Values.mariaDB.serviceName }}"
+              key: "{{ .Values.mariaDB.password }}"
+          JAEGER_AGENT_HOST: agent  # change depending on your jaeger deployment
+          JAEGER_SAMPLER_TYPE: const
+          JAEGER_SAMPLER_PARAM: 0
+          JAEGER_DISABLED: true
+          ASPNETCORE_ENVIRONMENT: Production
+          API_PATH: /ad-service
+          USER_AUTH_SERVICE_ADDRESS: unguard-user-auth-service
 
-  service:
-    type: ClusterIP
-    ports:
-      - name: http
-        targetPort: 8080
-        port: 8080
-      - name: health
-        targetPort: 8081
-        port: 8081
+  # Add Service
+  adService:
+    name: ad-service
 
-  deployment:
-    strategy:
-      type: RollingUpdate
-    container:
-      image:
-        repository: ghcr.io/dynatrace-oss/unguard/unguard-envoy-proxy
-        tag: 0.11.2
-        pullPolicy: IfNotPresent
+    service:
+      type: ClusterIP
+      ports:
+        - targetPort: 8082
+          port: 80
+
+    deployment:
+      strategy:
+        type: Recreate
+      container:
+        image:
+          repository: ghcr.io/dynatrace-oss/unguard/unguard-ad-service
+          tag: 0.11.2
+          pullPolicy: IfNotPresent
+        ports:
+          containerPort: 8082
+        env:
+          JAEGER_AGENT_HOST: agent  # change depending on your jaeger deployment
+          JAEGER_SAMPLER_TYPE: const
+          JAEGER_SAMPLER_PARAM: 0
+          JAEGER_DISABLED: true
+          ASPNETCORE_ENVIRONMENT: Production
+          SERVER_PORT: 8082
+          API_PATH: /ad-service
+          USER_AUTH_SERVICE_ADDRESS: unguard-user-auth-service
+
+  # Envoy Proxy
+  envoyProxy:
+    name: envoy-proxy
+
+    service:
+      type: ClusterIP
       ports:
         - name: http
-          containerPort: 8080
+          targetPort: 8080
+          port: 8080
         - name: health
-          containerPort: 8081
+          targetPort: 8081
+          port: 8081
 
-# Microblog Service
-microblogService:
-  name: microblog-service
+    deployment:
+      strategy:
+        type: RollingUpdate
+      container:
+        image:
+          repository: ghcr.io/dynatrace-oss/unguard/unguard-envoy-proxy
+          tag: 0.11.2
+          pullPolicy: IfNotPresent
+        ports:
+          - name: http
+            containerPort: 8080
+          - name: health
+            containerPort: 8081
 
-  service:
-    type: ClusterIP
-    ports:
-      - targetPort: 8080
-        port: 80
+  # Microblog Service
+  microblogService:
+    name: microblog-service
 
-  deployment:
-    strategy:
-      type: Recreate
-    container:
-      image:
-        repository: ghcr.io/dynatrace-oss/unguard/unguard-microblog-service
-        tag: 0.11.2
-        pullPolicy: IfNotPresent
+    service:
+      type: ClusterIP
       ports:
-        containerPort: 8080
-      env:
-        SERVER_PORT: 8080
-        JAEGER_AGENT_HOST: agent  # change depending on your jaeger deployment
-        JAEGER_SAMPLER_TYPE: const
-        JAEGER_SAMPLER_PARAM: 0
-        OPENTRACING_JAEGER_ENABLED: false
-        REDIS_SERVICE_ADDRESS: unguard-redis
-        USER_AUTH_SERVICE_ADDRESS: unguard-user-auth-service
+        - targetPort: 8080
+          port: 80
 
-# Status Service
-statusService:
-  name: status-service
+    deployment:
+      strategy:
+        type: Recreate
+      container:
+        image:
+          repository: ghcr.io/dynatrace-oss/unguard/unguard-microblog-service
+          tag: 0.11.2
+          pullPolicy: IfNotPresent
+        ports:
+          containerPort: 8080
+        env:
+          SERVER_PORT: 8080
+          JAEGER_AGENT_HOST: agent  # change depending on your jaeger deployment
+          JAEGER_SAMPLER_TYPE: const
+          JAEGER_SAMPLER_PARAM: 0
+          OPENTRACING_JAEGER_ENABLED: false
+          REDIS_SERVICE_ADDRESS: unguard-redis
+          USER_AUTH_SERVICE_ADDRESS: unguard-user-auth-service
 
-  service:
-    type: ClusterIP
-    ports:
-      - targetPort: 8083
-        port: 80
+  # Status Service
+  statusService:
+    name: status-service
 
-  serviceAccount:
-    name: unguard-status
+    service:
+      type: ClusterIP
+      ports:
+        - targetPort: 8083
+          port: 80
 
-  role:
-    name: status-role
-    rules:
-      - apiGroups: ["apps"]
-        resources: ["deployments"]
-        verbs: ["get", "list"]
-      - apiGroups: [""]
-        resources: ["pods"]
-        verbs: ["get", "list"]
+    serviceAccount:
+      name: unguard-status
 
-  roleBindings:
-    name: status-rolebinding
-    subjects:
-      - kind: ServiceAccount
-        name: unguard-status
-        apiGroup: ""
-    roleRef:
-      kind: Role
+    role:
       name: status-role
-      apiGroup: rbac.authorization.k8s.io
+      rules:
+        - apiGroups: ["apps"]
+          resources: ["deployments"]
+          verbs: ["get", "list"]
+        - apiGroups: [""]
+          resources: ["pods"]
+          verbs: ["get", "list"]
 
-  deployment:
-    strategy:
-      type: Recreate
-    container:
-      image:
-        repository: ghcr.io/dynatrace-oss/unguard/unguard-status-service
-        tag: 0.11.2
-        pullPolicy: IfNotPresent
+    roleBindings:
+      name: status-rolebinding
+      subjects:
+        - kind: ServiceAccount
+          name: unguard-status
+          apiGroup: ""
+      roleRef:
+        kind: Role
+        name: status-role
+        apiGroup: rbac.authorization.k8s.io
+
+    deployment:
+      strategy:
+        type: Recreate
+      container:
+        image:
+          repository: ghcr.io/dynatrace-oss/unguard/unguard-status-service
+          tag: 0.11.2
+          pullPolicy: IfNotPresent
+        ports:
+          containerPort: 8083
+        env:
+          SERVER_PORT: 8083
+          API_PATH: /status-service
+          KUBERNETES_NAMESPACE: unguard
+          IGNORED_DEPLOYMENTS: unguard-user-simulator  # add deployments to ignore separated by spaces
+          MARIADB_SERVICE: "{{ .Values.mariaDB.serviceName }}"
+          MARIADB_PASSWORD:
+            secretKeyRef:
+              name: "{{ .Values.mariaDB.serviceName }}"
+              key: "{{ .Values.mariaDB.password }}"
+
+  # Proxy Service
+  proxyService:
+    name: proxy-service
+
+    service:
+      type: ClusterIP
       ports:
-        containerPort: 8083
-      env:
-        SERVER_PORT: 8083
-        API_PATH: /status-service
-        KUBERNETES_NAMESPACE: unguard
-        IGNORED_DEPLOYMENTS: unguard-user-simulator  # add deployments to ignore separated by spaces
-        MARIADB_SERVICE: "{{ .Values.mariaDB.serviceName }}"
-        MARIADB_PASSWORD:
-          secretKeyRef:
-            name: "{{ .Values.mariaDB.serviceName }}"
-            key: "{{ .Values.mariaDB.password }}"
+        - targetPort: 8081
+          port: 80
 
-# Proxy Service
-proxyService:
-  name: proxy-service
+    serviceAccount:
+      name: unguard-proxy
 
-  service:
-    type: ClusterIP
-    ports:
-      - targetPort: 8081
-        port: 80
-
-  serviceAccount:
-    name: unguard-proxy
-
-  role:
-    name: proxy-role
-    rules:
-      - apiGroups: [""]  # "" indicates the core API group
-        resources: ["pods"]
-        verbs: ["create", "list", "get"]
-      - apiGroups: [""]
-        resources: ["pods/exec"]
-        verbs: ["create"]
-
-  roleBindings:
-    name: proxy-rolebinding
-    subjects:
-      - kind: ServiceAccount
-        name: unguard-proxy
-        apiGroup: ""
-    roleRef:
-      kind: Role
+    role:
       name: proxy-role
-      apiGroup: rbac.authorization.k8s.io
+      rules:
+        - apiGroups: [""]  # "" indicates the core API group
+          resources: ["pods"]
+          verbs: ["create", "list", "get"]
+        - apiGroups: [""]
+          resources: ["pods/exec"]
+          verbs: ["create"]
 
-  deployment:
-    strategy:
-      type: Recreate
-    container:
-      image:
-        repository: ghcr.io/dynatrace-oss/unguard/unguard-proxy-service
-        tag: 0.11.2
-        pullPolicy: IfNotPresent
+    roleBindings:
+      name: proxy-rolebinding
+      subjects:
+        - kind: ServiceAccount
+          name: unguard-proxy
+          apiGroup: ""
+      roleRef:
+        kind: Role
+        name: proxy-role
+        apiGroup: rbac.authorization.k8s.io
+
+    deployment:
+      strategy:
+        type: Recreate
+      container:
+        image:
+          repository: ghcr.io/dynatrace-oss/unguard/unguard-proxy-service
+          tag: 0.11.2
+          pullPolicy: IfNotPresent
+        ports:
+          containerPort: 8081
+        env:
+          SERVER_PORT: 8081
+          JAEGER_AGENT_HOST: agent  # change depending on your jaeger deployment
+          JAEGER_SAMPLER_TYPE: const
+          JAEGER_SAMPLER_PARAM: 0
+          OPENTRACING_JAEGER_ENABLED: false
+
+  # Like Service
+  likeService:
+    name: like-service
+
+    service:
+      type: ClusterIP
       ports:
-        containerPort: 8081
-      env:
-        SERVER_PORT: 8081
-        JAEGER_AGENT_HOST: agent  # change depending on your jaeger deployment
-        JAEGER_SAMPLER_TYPE: const
-        JAEGER_SAMPLER_PARAM: 0
-        OPENTRACING_JAEGER_ENABLED: false
+        - targetPort: 8000
+          port: 80
 
-# Like Service
-likeService:
-  name: like-service
+    deployment:
+      strategy:
+        type: Recreate
+      container:
+        image:
+          repository: ghcr.io/dynatrace-oss/unguard/unguard-like-service
+          tag: 0.11.2
+          pullPolicy: IfNotPresent
+        ports:
+          containerPort: 8000
+        env:
+          JAEGER_COLLECTOR_HOST: collector  # PHP OpenTelemetry sends data to jaeger-collector instead of jaeger-agent
+          JAEGER_DISABLED: true
+          JAEGER_PORT: 4318
+          SERVICE_NAME: unguard-like-service
+          SERVER_PORT: 8000
+          API_PATH: /like-service
+          USER_AUTH_SERVICE_ADDRESS: unguard-user-auth-service
+          DB_HOST: "{{ .Values.mariaDB.serviceName }}"
+          DB_PORT: "3306"
+          MARIADB_PASSWORD:
+            secretKeyRef:
+              name: "{{ .Values.mariaDB.serviceName }}"
+              key: "{{ .Values.mariaDB.password }}"
 
-  service:
-    type: ClusterIP
-    ports:
-      - targetPort: 8000
+  # Payment Service
+  paymentService:
+    name: payment-service
+
+    containerPort: 8084
+
+    service:
+      type: ClusterIP
+      ports:
         port: 80
 
-  deployment:
-    strategy:
-      type: Recreate
-    container:
-      image:
-        repository: ghcr.io/dynatrace-oss/unguard/unguard-like-service
-        tag: 0.11.2
-        pullPolicy: IfNotPresent
+    deployment:
+      strategy:
+        type: Recreate
+      container:
+        image:
+          repository: ghcr.io/dynatrace-oss/unguard/unguard-payment-service
+          tag: 0.11.2
+          pullPolicy: IfNotPresent
+        env:
+          API_PATH: /payment-service
+          OTEL_LOGS_EXPORTER: none
+          OTEL_METRICS_EXPORTER: none
+          OTEL_RESOURCE_ATTRIBUTES: service.name=unguard-payment-service
+          OTEL_TRACES_EXPORTER: none
+          OTEL_EXPERIMENTAL_SDK_ENABLED: false
+          OTEL_EXPORTER_OTLP_ENDPOINT: "http://jaeger-collector:4318"
+          OTEL_EXPORTER_OTLP_PROTOCOL: "http/protobuf"
+          OTEL_PROPAGATORS: "jaeger"
+          OTEL_PYTHON_LOGGING_AUTO_INSTRUMENTATION_ENABLED: false
+
+  # Frontend
+  frontend:
+    name: frontend
+
+    service:
+      type: ClusterIP
       ports:
-        containerPort: 8000
-      env:
-        JAEGER_COLLECTOR_HOST: collector  # PHP OpenTelemetry sends data to jaeger-collector instead of jaeger-agent
-        JAEGER_DISABLED: true
-        JAEGER_PORT: 4318
-        SERVICE_NAME: unguard-like-service
-        SERVER_PORT: 8000
-        API_PATH: /like-service
-        USER_AUTH_SERVICE_ADDRESS: unguard-user-auth-service
-        DB_HOST: "{{ .Values.mariaDB.serviceName }}"
-        DB_PORT: "3306"
-        MARIADB_PASSWORD:
-          secretKeyRef:
-            name: "{{ .Values.mariaDB.serviceName }}"
-            key: "{{ .Values.mariaDB.password }}"
+        - targetPort: 3000
+          port: 80
 
-# Payment Service
-paymentService:
-  name: payment-service
+    deployment:
+      strategy:
+        type: Recreate
+      container:
+        image:
+          repository: ghcr.io/dynatrace-oss/unguard/unguard-frontend
+          tag: 0.11.2
+          pullPolicy: IfNotPresent
+        ports:
+          containerPort: 3000
+        env:
+          JAEGER_AGENT_HOST: agent  # change depending on your jaeger deployment
+          JAEGER_SAMPLER_TYPE: const
+          JAEGER_SAMPLER_PARAM: 0
+          JAEGER_DISABLED: true
+          MICROBLOG_SERVICE_ADDRESS: unguard-microblog-service
+          PROXY_SERVICE_ADDRESS: unguard-proxy-service
+          USER_AUTH_SERVICE_ADDRESS: unguard-user-auth-service
+          AD_SERVICE_ADDRESS: unguard-ad-service
+          STATUS_SERVICE_ADDRESS: unguard-status-service
+          MEMBERSHIP_SERVICE_ADDRESS: unguard-membership-service
+          PROFILE_SERVICE_ADDRESS: unguard-profile-service
+          LIKE_SERVICE_ADDRES: unguard-like-service
+          PAYMENT_SERVICE_ADDRESS: unguard-payment-service
+          FRONTEND_BASE_PATH: /ui
+          AD_SERVICE_BASE_PATH: /ad-service
+          LIKE_SERVICE_BASE_PATH: /like-service
+          MEMBERSHIP_SERVICE_BASE_PATH: /membership-service
+          STATUS_SERVICE_BASE_PATH: /status-service
 
-  containerPort: 8084
+exploit-toolkit:
+  enabled: false
 
-  service:
-    type: ClusterIP
-    ports:
-      port: 80
-
-  deployment:
-    strategy:
-      type: Recreate
-    container:
-      image:
-        repository: ghcr.io/dynatrace-oss/unguard/unguard-payment-service
-        tag: 0.11.2
-        pullPolicy: IfNotPresent
-      env:
-        API_PATH: /payment-service
-        OTEL_LOGS_EXPORTER: none
-        OTEL_METRICS_EXPORTER: none
-        OTEL_RESOURCE_ATTRIBUTES: service.name=unguard-payment-service
-        OTEL_TRACES_EXPORTER: none
-        OTEL_EXPERIMENTAL_SDK_ENABLED: false
-        OTEL_EXPORTER_OTLP_ENDPOINT: "http://jaeger-collector:4318"
-        OTEL_EXPORTER_OTLP_PROTOCOL: "http/protobuf"
-        OTEL_PROPAGATORS: "jaeger"
-        OTEL_PYTHON_LOGGING_AUTO_INSTRUMENTATION_ENABLED: false
-
-# Frontend
-frontend:
-  name: frontend
-
-  service:
-    type: ClusterIP
-    ports:
-      - targetPort: 3000
-        port: 80
-
-  deployment:
-    strategy:
-      type: Recreate
-    container:
-      image:
-        repository: ghcr.io/dynatrace-oss/unguard/unguard-frontend
-        tag: 0.11.2
-        pullPolicy: IfNotPresent
-      ports:
-        containerPort: 3000
-      env:
-        JAEGER_AGENT_HOST: agent  # change depending on your jaeger deployment
-        JAEGER_SAMPLER_TYPE: const
-        JAEGER_SAMPLER_PARAM: 0
-        JAEGER_DISABLED: true
-        MICROBLOG_SERVICE_ADDRESS: unguard-microblog-service
-        PROXY_SERVICE_ADDRESS: unguard-proxy-service
-        USER_AUTH_SERVICE_ADDRESS: unguard-user-auth-service
-        AD_SERVICE_ADDRESS: unguard-ad-service
-        STATUS_SERVICE_ADDRESS: unguard-status-service
-        MEMBERSHIP_SERVICE_ADDRESS: unguard-membership-service
-        PROFILE_SERVICE_ADDRESS: unguard-profile-service
-        LIKE_SERVICE_ADDRES: unguard-like-service
-        PAYMENT_SERVICE_ADDRESS: unguard-payment-service
-        FRONTEND_BASE_PATH: /ui
-        AD_SERVICE_BASE_PATH: /ad-service
-        LIKE_SERVICE_BASE_PATH: /like-service
-        MEMBERSHIP_SERVICE_BASE_PATH: /membership-service
-        STATUS_SERVICE_BASE_PATH: /status-service

--- a/chart/values.yaml
+++ b/chart/values.yaml
@@ -506,3 +506,4 @@ exploit_toolkit:
         pullPolicy: IfNotPresent
   script: |
     /usr/local/bin/ug-exploit login exploit-demo --target totally-secure-unguard.dynatrace.com && /usr/local/bin/ug-exploit cmd-inject-proxy --target totally-secure-unguard.dynatrace.com "whoami"
+


### PR DESCRIPTION
This MR introduces breaking changes! 

- All unguard workloads are now put under a single element called unguard
- This enables users to not deploy unguard itself, but solely the exploit-toolkit by setting `unguard.enabled` to `false`
- A CronJob template was added for the exploit-toolkit
- `values.yaml` now contains an example config of how to deploy the exploit-toolkit
