### PR TITLE
:sparkles: feat(frontend): Display app health in footer

### DIFF
--- a/src/frontend-nextjs/app/api/deployment-health/route.ts
+++ b/src/frontend-nextjs/app/api/deployment-health/route.ts
@@ -1,0 +1,9 @@
+import { NextResponse } from 'next/server';
+
+import { fetchDeploymentHealth } from '@/services/api/DeploymentHealthService';
+
+export async function GET(): Promise<NextResponse> {
+    const res = await fetchDeploymentHealth();
+
+    return NextResponse.json(res.data, { status: res.status });
+}

--- a/src/frontend-nextjs/app/layout.tsx
+++ b/src/frontend-nextjs/app/layout.tsx
@@ -6,7 +6,7 @@ import { Providers } from './providers';
 
 import { siteConfig } from '@/config/site';
 import { NavigationBar } from '@/components/Navbar/NavigationBar';
-import { Footer } from '@/components/Footer';
+import { Footer } from '@/components/Footer/Footer';
 import { BASE_PATH } from '@/constants';
 
 export const metadata: Metadata = {

--- a/src/frontend-nextjs/app/mytimeline/page.tsx
+++ b/src/frontend-nextjs/app/mytimeline/page.tsx
@@ -18,7 +18,7 @@ export default function MyTimeline() {
     return (
         <div>
             <h1 className='mb-6 text-4xl font-extrabold leading-none tracking-tight text-gray-800'>My Timeline</h1>
-            <div className='grid gap-8 grid-cols-[70%_30%] min-h-screen'>
+            <div className='grid gap-8 grid-cols-[70%_30%]'>
                 <div>
                     <CreatePost />
                     <ErrorBoundary fallbackRender={(props) => <ErrorCard message={props.error.message} />}>

--- a/src/frontend-nextjs/app/page.tsx
+++ b/src/frontend-nextjs/app/page.tsx
@@ -7,7 +7,7 @@ export default async function Home() {
     return (
         <div>
             <h1 className='mb-6 text-4xl font-extrabold leading-none tracking-tight text-gray-800'>Timeline</h1>
-            <div className='grid gap-8 grid-cols-[70%_30%] min-h-screen'>
+            <div className='grid gap-8 grid-cols-[70%_30%]'>
                 <div>
                     {(await isLoggedIn()) && <CreatePost />}
                     <GlobalTimeline />

--- a/src/frontend-nextjs/app/users/page.tsx
+++ b/src/frontend-nextjs/app/users/page.tsx
@@ -5,7 +5,7 @@ export default function Users() {
     return (
         <div>
             <h1 className='mb-6 text-4xl font-extrabold leading-none tracking-tight text-gray-800'>Users</h1>
-            <div className='grid gap-8 grid-cols-[70%_30%] min-h-screen'>
+            <div className='grid gap-8 grid-cols-[70%_30%]'>
                 <UserSearch />
                 <Ad />
             </div>

--- a/src/frontend-nextjs/components/Footer/DeploymentHealthTable.tsx
+++ b/src/frontend-nextjs/components/Footer/DeploymentHealthTable.tsx
@@ -1,0 +1,47 @@
+import { getKeyValue, Table, TableBody, TableCell, TableColumn, TableHeader, TableRow } from '@heroui/react';
+import React from 'react';
+
+import { DeploymentDetails } from '@/hooks/queries/useDeploymentHealth';
+
+export interface DeploymentHealthTableProps {
+    tableData: DeploymentDetails[];
+}
+
+export function DeploymentHealthTable(props: DeploymentHealthTableProps) {
+    return (
+        <Table
+            aria-label='Deployment Health Table'
+            classNames={{
+                base: 'overflow-scroll',
+                table: 'min-h-[400px]',
+            }}
+        >
+            <TableHeader>
+                <TableColumn key='microservice' className='text-default-800 text-medium'>
+                    Microservice
+                </TableColumn>
+                <TableColumn key='status' className='text-default-800 text-medium'>
+                    Status
+                </TableColumn>
+                <TableColumn key='availableReplicas' className='text-default-800 text-medium'>
+                    Available Replicas
+                </TableColumn>
+            </TableHeader>
+            <TableBody items={props.tableData}>
+                {(item) => (
+                    <TableRow key={item.microservice}>
+                        {(columnKey) => (
+                            <TableCell
+                                className={
+                                    columnKey === 'status' ? (item.isHealthy ? 'text-success' : 'text-danger') : ''
+                                }
+                            >
+                                {getKeyValue(item, columnKey)}
+                            </TableCell>
+                        )}
+                    </TableRow>
+                )}
+            </TableBody>
+        </Table>
+    );
+}

--- a/src/frontend-nextjs/components/Footer/DeploymentStatus.tsx
+++ b/src/frontend-nextjs/components/Footer/DeploymentStatus.tsx
@@ -1,0 +1,67 @@
+import React from 'react';
+import {
+    Spinner,
+    Modal,
+    ModalContent,
+    ModalHeader,
+    ModalBody,
+    ModalFooter,
+    Button,
+    useDisclosure,
+} from '@heroui/react';
+import { ErrorBoundary } from 'react-error-boundary';
+
+import { useDeploymentHealth } from '@/hooks/queries/useDeploymentHealth';
+import { ErrorCard } from '@/components/ErrorCard';
+import { DeploymentHealthTable } from '@/components/Footer/DeploymentHealthTable';
+
+function DeploymentStatusComponent() {
+    const { deploymentHealthData, isLoading } = useDeploymentHealth();
+    const { isOpen, onOpen, onOpenChange } = useDisclosure();
+
+    if (isLoading) return <Spinner />;
+
+    return (
+        <div>
+            <Button
+                className='underline cursor-pointer text-medium'
+                color={
+                    deploymentHealthData.availableDeployments === deploymentHealthData.totalDeployments
+                        ? 'success'
+                        : 'danger'
+                }
+                variant='light'
+                onPress={onOpen}
+            >
+                {deploymentHealthData.availableDeployments == deploymentHealthData.totalDeployments
+                    ? 'App is healthy'
+                    : `${deploymentHealthData.availableDeployments}/${deploymentHealthData.totalDeployments} deployments available`}
+            </Button>
+            <Modal isOpen={isOpen} size='xl' onOpenChange={onOpenChange}>
+                <ModalContent>
+                    {(onClose) => (
+                        <>
+                            <ModalHeader className='pl-10 pt-8'>
+                                <h2 className='text-2xlxl font-semibold text-default-800'>App Health</h2>
+                            </ModalHeader>
+                            <ModalBody>
+                                <DeploymentHealthTable tableData={deploymentHealthData.deploymentDetails} />
+                            </ModalBody>
+                            <ModalFooter>
+                                <Button onPress={onClose}>Close</Button>
+                            </ModalFooter>
+                        </>
+                    )}
+                </ModalContent>
+            </Modal>
+        </div>
+    );
+}
+
+export function DeploymentStatus() {
+    return (
+        <ErrorBoundary fallbackRender={(props) => <ErrorCard message={props.error.message} />}>
+            <DeploymentStatusComponent />
+        </ErrorBoundary>
+    );
+}

--- a/src/frontend-nextjs/components/Footer/Footer.tsx
+++ b/src/frontend-nextjs/components/Footer/Footer.tsx
@@ -1,6 +1,8 @@
 'use client';
 import { Link } from '@heroui/react';
 
+import { DeploymentStatus } from '@/components/Footer/DeploymentStatus';
+
 export function Footer() {
     return (
         <div>
@@ -8,6 +10,7 @@ export function Footer() {
             <p>
                 Robots lovingly delivered by <Link href='https://robohash.org/'>Robohash.org</Link>
             </p>
+            <DeploymentStatus />
         </div>
     );
 }

--- a/src/frontend-nextjs/enums/queryKeys.ts
+++ b/src/frontend-nextjs/enums/queryKeys.ts
@@ -16,4 +16,5 @@ export enum QUERY_KEYS {
     payment_data = 'payment-data',
     ad_manager = 'ad-manager',
     ad_list = 'ad-list',
+    deployment_health = 'deployment-health',
 }

--- a/src/frontend-nextjs/hooks/queries/useDeploymentHealth.ts
+++ b/src/frontend-nextjs/hooks/queries/useDeploymentHealth.ts
@@ -1,0 +1,58 @@
+import path from 'path';
+
+import { useQuery } from '@tanstack/react-query';
+
+import { QUERY_KEYS } from '@/enums/queryKeys';
+import { BASE_PATH } from '@/constants';
+
+export type DeploymentDetails = {
+    microservice: string;
+    status: string;
+    availableReplicas: number;
+    isHealthy: boolean;
+};
+
+export type DeploymentHealthData = {
+    availableDeployments: number;
+    totalDeployments: number;
+    deploymentDetails: DeploymentDetails[];
+};
+
+async function fetchDeploymentHealth(): Promise<any> {
+    const res = await fetch(path.join(BASE_PATH, '/api/deployment-health'));
+
+    if (!res.ok) {
+        throw new Error('Failed to fetch deployment health');
+    }
+
+    return res.json();
+}
+
+function prepareDeploymentHealthData(rawData: any): DeploymentHealthData {
+    const availableDeployments = rawData?.available ?? 0;
+    const totalDeployments = rawData?.total ?? 0;
+    const deployments = rawData?.microservices ?? {};
+
+    const deploymentDetails: DeploymentDetails[] = Object.entries(deployments).map(([name, health]: any) => ({
+        microservice: name,
+        status: health.healthy ? 'Available' : 'Failing',
+        availableReplicas: rawData?.[name]?.status?.availableReplicas ?? 0,
+        isHealthy: health.healthy,
+    }));
+
+    return {
+        availableDeployments: availableDeployments,
+        totalDeployments: totalDeployments,
+        deploymentDetails: deploymentDetails,
+    };
+}
+
+export function useDeploymentHealth() {
+    const { data, ...rest } = useQuery({
+        queryKey: [QUERY_KEYS.deployment_health],
+        queryFn: fetchDeploymentHealth,
+        throwOnError: true,
+    });
+
+    return { deploymentHealthData: prepareDeploymentHealthData(data), ...rest };
+}

--- a/src/frontend-nextjs/services/api/DeploymentHealthService.ts
+++ b/src/frontend-nextjs/services/api/DeploymentHealthService.ts
@@ -1,0 +1,23 @@
+import { AxiosResponse } from 'axios';
+import { getStatusServiceApi } from '@/axios';
+
+export async function fetchDeploymentHealth(): Promise<any> {
+    const statusServiceApi = getStatusServiceApi();
+
+    try {
+        const [deploymentDetails, deploymentHealth] = await Promise.all([
+            statusServiceApi.get('deployments'),
+            statusServiceApi.get('deployments/health'),
+        ]);
+
+        return {
+            ...deploymentHealth,
+            data: {
+                ...deploymentDetails.data,
+                ...deploymentHealth.data,
+            },
+        };
+    } catch (error: any) {
+        return error.response;
+    }
+}


### PR DESCRIPTION
- The application health information is accessible through a button in the footer showing the number of available deployments.
- The status and available replicas for each microservice are displayed in a table