### PR TITLE
🐛 fix: Make services wait (and fail-fast) for MariaDB to avoid race condition

### DIFF
--- a/chart/templates/_helpers.tpl
+++ b/chart/templates/_helpers.tpl
@@ -38,3 +38,15 @@ If release name contains chart name it will be used as a full name.
 {{ $key }}: {{ $value }}
 {{- end -}}
 {{- end -}}
+
+{{/*
+Init container that blocks until MariaDB is accepting TCP connections on port 3306.
+Usage: {{- include "unguard.waitForMariaDB" . | nindent 8 }}
+*/}}
+{{- define "unguard.waitForMariaDB" -}}
+- name: wait-for-mariadb
+  image: busybox:1.37
+  command: ["/bin/sh", "-c"]
+  args:
+    - "until nc -z {{ .Values.mariaDB.serviceName }} 3306; do echo 'Waiting for MariaDB...'; sleep 2; done"
+{{- end -}}

--- a/chart/templates/like-service.yaml
+++ b/chart/templates/like-service.yaml
@@ -52,6 +52,8 @@ spec:
         app.kubernetes.io/part-of: unguard
 {{ include "renderLabels" .Values.labels.common | indent 8 }}
     spec:
+      initContainers:
+        {{- include "unguard.waitForMariaDB" . | nindent 8 }}
       containers:
         - name: {{ .Values.likeService.name }}
           image: {{ .Values.likeService.deployment.container.image.repository }}:{{ .Values.likeService.deployment.container.image.tag }}

--- a/chart/templates/membership-service.yaml
+++ b/chart/templates/membership-service.yaml
@@ -52,6 +52,8 @@ spec:
         app.kubernetes.io/part-of: unguard
 {{ include "renderLabels" .Values.labels.common | indent 8 }}
     spec:
+      initContainers:
+        {{- include "unguard.waitForMariaDB" . | nindent 8 }}
       containers:
         - name: {{ .Values.membershipService.name }}
           image: {{ .Values.membershipService.deployment.container.image.repository }}:{{ .Values.membershipService.deployment.container.image.tag }}

--- a/chart/templates/status-service.yaml
+++ b/chart/templates/status-service.yaml
@@ -92,6 +92,8 @@ spec:
 {{ include "renderLabels" .Values.labels.common | indent 8 }}
     spec:
       serviceAccountName: {{ .Values.statusService.serviceAccount.name }}
+      initContainers:
+        {{- include "unguard.waitForMariaDB" . | nindent 8 }}
       containers:
         - name: {{ .Values.statusService.name }}
           image: {{ .Values.statusService.deployment.container.image.repository }}:{{ .Values.statusService.deployment.container.image.tag }}

--- a/chart/templates/user-auth-service.yaml
+++ b/chart/templates/user-auth-service.yaml
@@ -53,6 +53,8 @@ spec:
         app.kubernetes.io/part-of: unguard
 {{ include "renderLabels" .Values.labels.common | indent 8 }}
     spec:
+      initContainers:
+        {{- include "unguard.waitForMariaDB" . | nindent 8 }}
       containers:
         - name: {{ .Values.userAuthService.name }}
           image: {{ .Values.userAuthService.deployment.container.image.repository }}:{{ .Values.userAuthService.deployment.container.image.tag }}

--- a/src/membership-service/Program.cs
+++ b/src/membership-service/Program.cs
@@ -43,18 +43,25 @@ namespace MembershipService
                     string dbHost = Environment.GetEnvironmentVariable("MARIADB_SERVICE");
                     var connectionString = $"Server={dbHost};Port=3306;Database=memberships;user=root;password={dbPwd}";
 
-                    // Check if MariaDB exists, if not, create it
-                    using (var connection = new MySqlConnection(connectionString))
+                    try
                     {
-                        try
+                        // Check if MariaDB exists, if not, create it
+                        using (var connection = new MySqlConnection(connectionString))
                         {
-                            connection.Open();
+                            try
+                            {
+                                connection.Open();
+                            }
+                            catch (MySqlException)
+                            {
+                                CreateMariaDBDatabase(connectionString);
+                            }
                         }
-                        catch (MySqlException)
-                        {
-                            // Database does not exist, create it
-                            CreateMariaDBDatabase(connectionString);
-                        }
+                    }
+                    catch (Exception ex)
+                    {
+                        Console.Error.WriteLine($"Fatal: database initialization failed: {ex.Message}");
+                        Environment.Exit(1);
                     }
                 });
 

--- a/src/user-auth-service/app.js
+++ b/src/user-auth-service/app.js
@@ -63,7 +63,10 @@ const opentracing = require('opentracing')
 opentracing.initGlobalTracer(tracer);
 
 app.use(tracingMiddleWare);
-initDb();
+initDb().catch(err => {
+  console.error('Fatal: database initialization failed', err);
+  process.exit(1);
+});
 
 //Here we are configuring express to use body-parser as middle-ware.
 app.use(bodyParser.urlencoded({ extended: false }));


### PR DESCRIPTION
Services depending on MariaDB (like-service, membership-service, status-service, user-auth-service) could start before the database was ready, causing schema initialization to fail silently or crash with an uncaught exception. Unguard was unusable; only a manual restart of the pods could resolve this.
                                                                                                                                                                                                                                          
This fix added a `wait-for-mariadb` init container to the four deployments, ensuring the pod only starts once MariaDB is ready. Additionally, schema initialization failures in user-auth-service and membership-service now log a clear error message and exit instead of failing silently, letting Kubernetes handle the restart rather than silently continuing with a broken state.                                                                                                                                                                                                                           
                                                            
Tested by deploying to our own cluster via `helm upgrade --reuse-values`.